### PR TITLE
feat: 增加 package.json, 新增 eslint & prettier 配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Dependencies
+node_modules/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Logs
+*.log
+npm-debug.log*
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Build
+dist/
+build/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,17 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+build/
+
+# Minified files
+*.min.js
+*.min.css
+
+# IDE
+.idea/
+.vscode/
+
+# Others
+*.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,22 @@
+{
+    "printWidth": 200,
+    "tabWidth": 4,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": false,
+    "quoteProps": "as-needed",
+    "jsxSingleQuote": false,
+    "trailingComma": "none",
+    "bracketSpacing": true,
+    "arrowParens": "avoid",
+    "proseWrap": "preserve",
+    "endOfLine": "auto",
+    "overrides": [
+        {
+            "files": "*.min.js",
+            "options": {
+                "printWidth": 10000
+            }
+        }
+    ]
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,43 @@
+import globals from 'globals';
+import js from '@eslint/js';
+import prettierPlugin from 'eslint-plugin-prettier';
+import prettierConfig from 'eslint-config-prettier';
+
+export default [
+    { files: ['**/*.js'] },
+    {
+        languageOptions: {
+            globals: {
+                ...globals.browser,
+                jQuery: 'readonly',
+                $: 'readonly',
+                toastr: 'readonly'
+            }
+        }
+    },
+    js.configs.recommended,
+    {
+        plugins: {
+            prettier: prettierPlugin
+        }
+    },
+    {
+        ignores: ['**/node_modules/**', '**/.idea/**'],
+    },
+    {
+        rules: {
+            ...prettierConfig.rules,
+            'prettier/prettier': 'error',
+            'prefer-const': 'error',
+            'no-unused-vars': ['error', { argsIgnorePattern: '^_|^e$', varsIgnorePattern: '^_|^e$', caughtErrorsIgnorePattern: '^_|^e$' }],
+            'no-control-regex': 'off',
+            'no-constant-condition': ['error', { checkLoops: false }],
+            'require-yield': 'off',
+            'no-unused-expressions': ['error', { allowShortCircuit: true, allowTernary: true }],
+            'no-cond-assign': 'error',
+            'no-unneeded-ternary': 'error',
+            'no-irregular-whitespace': ['error', { skipStrings: true, skipTemplates: true }],
+            'no-empty': 'off',
+        },
+    },
+];

--- a/message-preview.js
+++ b/message-preview.js
@@ -687,6 +687,7 @@ const recordInterceptedId = (id) => { if ((S.isPreview || S.isLong) && !S.interc
 async function deleteMessageById(id) {
   try {
     const ctx = getContext();
+    /* global deleteLastMessage */
     if (id === ctx.chat?.length - 1) { if (typeof deleteLastMessage === "function") { await deleteLastMessage(); return true; } }
     if (ctx.chat && ctx.chat[id]) { ctx.chat.splice(id, 1); $(`#chat .mes[mesid="${id}"]`).remove(); if (ctx.chat_metadata) ctx.chat_metadata.tainted = true; return true; }
     const el = $(`#chat .mes[mesid="${id}"]`); if (el.length) { el.remove(); return true; }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "littlewhitebox",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Frontend project with ESLint configuration",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.23.0",
+    "@types/jquery": "^3.5.33",
+    "@types/toastr": "^2.1.43",
+    "eslint": "^9.23.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.2.1",
+    "globals": "^15.0.0",
+    "prettier": "^3.3.3"
+  }
+}


### PR DESCRIPTION
对于下面类型的错误，我没有配置 eslint 忽略：
 - `no-dupe-keys` 实际上发生重复的key，只有最后出现的会保留，应当与你的预期不符。
 - `prefer-const` 好习惯
 - `no-unused-vars` 发生这个错误大概率是代码有地方写错了，如果一定用不到，可以给变量加 `_` 前缀
 - `no-unneeded-ternary` js 已经进行隐式类型转换，实质是多余的。

这些应该也可以用eslint自动修掉一部分，也就是 `lint:fix`

如果不想让prettier 包含在 eslint 里面，把下面的内容
```
        rules: {
            ...prettierConfig.rules,
            'prettier/prettier': 'error',
```
修改成
```
        rules: {
            ...prettierConfig.rules,
            'prettier/prettier': 'off',
```
即可。