### PR TITLE
Strip everything before and including </think>

### DIFF
--- a/modules/ena-planner/ena-planner.js
+++ b/modules/ena-planner/ena-planner.js
@@ -307,7 +307,8 @@ function formatCharCardBlock(charObj) {
 function cleanAiMessageText(text) {
     let out = String(text ?? '');
 
-    // 1) Strip properly wrapped <think>/<thinking> blocks only.
+    // 1) Strip everything before and including </think> (handles unclosed think blocks)
+    out = out.replace(/^[\s\S]*?<\/think>/i, '');
     out = out.replace(/<think\b[^>]*>[\s\S]*?<\/think>/gi, '');
     out = out.replace(/<thinking\b[^>]*>[\s\S]*?<\/thinking>/gi, '');
 


### PR DESCRIPTION
在前文摘取部分，发现没有截掉/think以前的思维链。因为有些预设为了强迫思考，所以在预设层面已经有了think开头，正文部分就只剩思考和/think，然后直接接正文了，因此摘取正文时要直接拿掉/think前的内容。

// 1) Strip everything before and including </think> (handles unclosed think blocks)
out = out.replace(/^[\s\S]*?<\/think>/i, '');