### PR TITLE
perf(novel-draw): 优化绘图渲染性能与持久化机制，实现轻量化局部更新与楼层元数据联动，新增角色服装列表

### DIFF
--- a/modules/novel-draw/gallery-cache.js
+++ b/modules/novel-draw/gallery-cache.js
@@ -178,7 +178,7 @@ export async function clearSlotSelection(slotId) {
 // ═══════════════════════════════════════════════════════════════════════════
 
 export async function storePreview(opts) {
-    const { imgId, slotId, messageId, base64 = null, tags, positive, savedUrl = null, status = 'success', errorType = null, errorMessage = null, characterPrompts = null, negativePrompt = null } = opts;
+    const { imgId, slotId, messageId, base64 = null, tags, positive, savedUrl = null, status = 'success', errorType = null, errorMessage = null, characterPrompts = null, negativePrompt = null, anchor = '' } = opts;
     const database = await openDB();
     const ctx = getContext();
     
@@ -200,6 +200,7 @@ export async function storePreview(opts) {
                 errorMessage,
                 characterPrompts,
                 negativePrompt,
+                anchor,
                 timestamp: Date.now()
             });
             tx.oncomplete = () => { invalidateCache(slotId); resolve(); };
@@ -291,8 +292,8 @@ export async function getDisplayPreviewForSlot(slotId) {
     const previews = await getPreviewsBySlot(slotId);
     if (!previews.length) return { preview: null, historyCount: 0, hasData: false, isFailed: false };
     
-    const successPreviews = previews.filter(p => p.status !== 'failed' && p.base64);
-    const failedPreviews = previews.filter(p => p.status === 'failed' || !p.base64);
+    const successPreviews = previews.filter(p => p.status !== 'failed' && (p.base64 || p.savedUrl));
+    const failedPreviews = previews.filter(p => p.status === 'failed' || (!p.base64 && !p.savedUrl));
     
     if (successPreviews.length === 0) {
         const latestFailed = failedPreviews[0];
@@ -345,7 +346,7 @@ export async function deletePreview(imgId) {
 
 export async function deleteFailedRecordsForSlot(slotId) {
     const previews = await getPreviewsBySlot(slotId);
-    const failedRecords = previews.filter(p => p.status === 'failed' || !p.base64);
+    const failedRecords = previews.filter(p => p.status === 'failed' || (!p.base64 && !p.savedUrl));
     for (const record of failedRecords) {
         await deletePreview(record.imgId);
     }
@@ -357,6 +358,7 @@ export async function updatePreviewSavedUrl(imgId, savedUrl) {
     if (!preview) return;
     
     preview.savedUrl = savedUrl;
+    preview.base64 = null;
     
     return new Promise((resolve, reject) => {
         try {
@@ -383,7 +385,7 @@ export async function getCacheStats() {
                 const cursor = e.target.result;
                 if (cursor) { 
                     totalSize += (cursor.value.base64?.length || 0) * 0.75;
-                    if (cursor.value.status === 'failed' || !cursor.value.base64) {
+                    if (cursor.value.status === 'failed' || (!cursor.value.base64 && !cursor.value.savedUrl)) {
                         failedCount++;
                     } else {
                         successCount++;
@@ -407,7 +409,7 @@ export async function getCacheStats() {
 export async function clearExpiredCache(cacheDays = 3) {
     const cutoff = Date.now() - cacheDays * 24 * 60 * 60 * 1000;
     const database = await openDB();
-    let deleted = 0;
+    let cleaned = 0;
     
     return new Promise((resolve) => {
         try {
@@ -418,15 +420,26 @@ export async function clearExpiredCache(cacheDays = 3) {
                 if (cursor) { 
                     const record = cursor.value;
                     const isExpiredUnsaved = record.timestamp < cutoff && !record.savedUrl;
-                    const isFailed = record.status === 'failed' || !record.base64;
+                    const isFailed = record.status === 'failed' || (!record.base64 && !record.savedUrl);
+                    const shouldTrimSavedBase64 = !!record.savedUrl && !!record.base64;
+
                     if (isExpiredUnsaved || (isFailed && record.timestamp < cutoff)) { 
                         cursor.delete(); 
-                        deleted++; 
-                    } 
+                        cleaned++; 
+                        cursor.continue(); 
+                        return;
+                    }
+
+                    if (shouldTrimSavedBase64) {
+                        record.base64 = null;
+                        cursor.update(record);
+                        cleaned++;
+                    }
+
                     cursor.continue(); 
                 }
             };
-            tx.oncomplete = () => { invalidateCache(); resolve(deleted); };
+            tx.oncomplete = () => { invalidateCache(); resolve(cleaned); };
         } catch {
             resolve(0);
         }
@@ -466,7 +479,7 @@ export async function getGallerySummary() {
                 const summary = {};
                 
                 for (const item of results) {
-                    if (item.status === 'failed' || !item.base64) continue;
+                    if (item.status === 'failed' || (!item.base64 && !item.savedUrl)) continue;
                     
                     const charName = item.characterName || 'Unknown';
                     if (!summary[charName]) {
@@ -515,7 +528,7 @@ export async function getCharacterPreviews(charName) {
                 
                 for (const item of results) {
                     if ((item.characterName || 'Unknown') !== charName) continue;
-                    if (item.status === 'failed' || !item.base64) continue;
+                    if (item.status === 'failed' || (!item.base64 && !item.savedUrl)) continue;
                     
                     const slotId = item.slotId || item.imgId;
                     if (!slots[slotId]) slots[slotId] = [];
@@ -572,7 +585,7 @@ export async function openGallery(slotId, messageId, callbacks = {}) {
     createGalleryOverlay();
     
     const previews = await getPreviewsBySlot(slotId);
-    const validPreviews = previews.filter(p => p.status !== 'failed' && p.base64);
+    const validPreviews = previews.filter(p => p.status !== 'failed' && (p.base64 || p.savedUrl));
     
     if (!validPreviews.length) {
         showToast('没有找到图片历史', 'error');

--- a/modules/novel-draw/llm-service.js
+++ b/modules/novel-draw/llm-service.js
@@ -267,7 +267,13 @@ export function buildCharacterInfoForLLM(presentCharacters) {
         const type = c.type || 'girl';
         const danbooru = c.danbooruTag ? ` | danbooru: ${c.danbooruTag}` : '';
         const appear = c.appearance ? `\n  外貌参考: ${c.appearance}` : '';
-        return `- ${c.name}${aliases} [${type}]${danbooru}: 外貌已预设，只需输出 name + danbooru + costume + action + interact + uc + center${appear}`;
+        const outfits = Array.isArray(c.outfits) && c.outfits.length
+            ? `\n  可选服装: ${c.outfits
+                .filter(o => o?.name || o?.tags)
+                .map(o => `${o.name || '服装'}=${o.tags || '未填写tag'}`)
+                .join('； ')}`
+            : '';
+        return `- ${c.name}${aliases} [${type}]${danbooru}: 外貌已预设，只需输出 name + danbooru + costume + action + interact + uc + center${appear}${outfits}`;
     });
 
     return `【已录入角色】(不要输出这些角色的 type/appear，但 costume 必须完整输出):

--- a/modules/novel-draw/novel-draw.html
+++ b/modules/novel-draw/novel-draw.html
@@ -168,7 +168,47 @@ select.input { cursor: pointer; }
     border-radius: 10px; margin-bottom: 16px; flex-wrap: wrap;
 }
 .preset-bar select { flex: 1; min-width: 120px; max-width: 200px; }
+.char-management-layout {
+    display: grid; grid-template-columns: minmax(280px, 320px) minmax(0, 1fr);
+    gap: 16px; align-items: start;
+}
+.char-management-sidebar {
+    display: flex; flex-direction: column; gap: 16px;
+    position: sticky; top: 0; align-self: start;
+}
+.char-summary-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+.char-summary-item {
+    background: var(--bg-tertiary); border: 1px solid var(--border);
+    border-radius: 10px; padding: 14px 12px;
+}
+.char-summary-label { font-size: 11px; color: var(--text-secondary); }
+.char-summary-value { font-size: 24px; font-weight: 700; margin-top: 4px; color: var(--text-primary); }
+.char-summary-value.accent { color: var(--accent); }
+.char-filter-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.char-filter-summary {
+    margin-top: 12px; font-size: 12px; color: var(--text-secondary);
+    padding: 10px 12px; border-radius: 8px; background: var(--bg-input); border: 1px solid var(--border);
+}
+.char-list-card { min-height: 520px; }
+.char-list-card-header {
+    display: flex; align-items: flex-start; justify-content: space-between;
+    gap: 12px; margin-bottom: 16px;
+}
+.char-list-card-header .card-title { margin-bottom: 0; }
+.char-list-count {
+    display: inline-flex; align-items: center; justify-content: center;
+    min-width: 84px; padding: 8px 12px; border-radius: 999px;
+    background: var(--accent-soft); color: var(--accent); font-size: 12px; font-weight: 600;
+}
+.char-list-body { display: flex; flex-direction: column; gap: 12px; }
 .char-grid { display: flex; flex-direction: column; gap: 0; }
+.char-grid:empty { display: none; }
+.char-empty.filtered {
+    background: var(--bg-tertiary); border: 1px dashed var(--border);
+    border-radius: 10px;
+}
+.char-empty strong { color: var(--text-primary); display: block; margin-bottom: 6px; font-size: 14px; }
+.char-empty p { font-size: 12px; margin-top: 6px; }
 .filter-rule-row { display: flex; align-items: center; gap: 6px; margin-bottom: 6px; }
 .filter-rule-row input { flex: 1; font-size: 13px; padding: 4px 8px; background: var(--bg-secondary); border: 1px solid var(--border); border-radius: 4px; color: var(--text-primary); }
 .filter-rule-row .rule-arrow { color: var(--text-muted); font-size: 11px; flex-shrink: 0; }
@@ -208,6 +248,22 @@ select.input { cursor: pointer; }
 .char-edit-form .form-label { font-size: 11px; margin-bottom: 4px; }
 .char-edit-form .input { padding: 8px 10px; font-size: 12px; }
 .char-edit-form textarea.input { min-height: 60px; }
+.char-outfit-editor-list { display: flex; flex-direction: column; gap: 10px; }
+.char-outfit-editor-empty {
+    padding: 10px 12px; border-radius: 8px; border: 1px dashed var(--border);
+    background: rgba(255,255,255,.02); color: var(--text-muted); font-size: 11px;
+}
+.char-outfit-editor-item {
+    padding: 12px; border-radius: 10px; border: 1px solid rgba(255,255,255,.08);
+    background: rgba(255,255,255,.03);
+}
+.char-outfit-editor-header {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 10px; margin-bottom: 10px;
+}
+.char-outfit-editor-title { font-size: 12px; font-weight: 600; color: var(--text-primary); }
+.char-outfit-editor-item .form-group:last-child { margin-bottom: 0; }
+.char-outfit-tags { min-height: 72px; }
 /* ── Toggle switch ── */
 .toggle-switch { position: relative; display: inline-block; width: 36px; height: 20px; flex-shrink: 0; }
 .toggle-switch input { opacity: 0; width: 0; height: 0; }
@@ -363,6 +419,10 @@ select.input { cursor: pointer; }
     .view-title { font-size: 18px; }
     .card { padding: 16px; }
     .form-row { grid-template-columns: 1fr; }
+    .char-management-layout { grid-template-columns: 1fr; }
+    .char-management-sidebar { position: static; }
+    .char-filter-row { grid-template-columns: 1fr; }
+    .char-list-card-header { flex-direction: column; }
     .preset-bar { padding: 10px 12px; }
     .preset-bar select { max-width: none; }
     .gallery-slots { grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 10px; padding: 12px; }
@@ -572,6 +632,7 @@ body.advanced-mode .nd-simple-only { display: none !important; }
             <div class="nav-item" data-view="params"><i class="fa-solid fa-sliders"></i>绘图参数</div>
             <div class="nav-item" data-view="llm"><i class="fa-solid fa-robot"></i>LLM 配置</div>
             <div class="nav-divider"></div>
+            <div class="nav-item" data-view="characters"><i class="fa-solid fa-user-group"></i>角色标签</div>
             <div class="nav-item" data-view="gallery"><i class="fa-solid fa-images"></i>图片管理</div>
             <div class="nav-divider nd-advanced-only"></div>
             <div class="nav-item nd-advanced-only" data-view="prompts"><i class="fa-solid fa-file-code"></i>提示词模板</div>
@@ -653,7 +714,7 @@ body.advanced-mode .nd-simple-only { display: none !important; }
             <div id="view-params" class="view">
                 <div class="view-header">
                     <h2 class="view-title">绘图参数</h2>
-                    <p class="view-desc">模型、生成参数与标签设置</p>
+                    <p class="view-desc">模型与生成参数设置</p>
                 </div>
                 
                 <div class="preset-bar">
@@ -808,55 +869,6 @@ body.advanced-mode .nd-simple-only { display: none !important; }
                         <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;margin-top:8px;"><input type="checkbox" id="nd_decrisper"> Decrisper</label>
                     </div>
                 </div>
-                
-                <div class="card" id="nd_char_card">
-                    <div class="char-section-header" id="nd_char_header">
-                        <div class="card-title">👥 角色标签</div>
-                        <i class="fa-solid fa-chevron-down char-section-toggle"></i>
-                    </div>
-                    <div class="char-section-content">
-                        <p class="form-hint" style="margin-bottom:12px;">预设角色外貌，LLM 只需补充动作和互动标签</p>
-                        <div class="btn-group" style="margin-bottom:12px;">
-                            <button id="nd_char_add" class="btn btn-primary btn-sm"><i class="fa-solid fa-plus"></i> 添加角色</button>
-                            <button id="nd_char_clear" class="btn btn-danger btn-sm"><i class="fa-solid fa-trash-can"></i> 清除全部</button>
-                            <button id="nd_char_export" class="btn btn-sm"><i class="fa-solid fa-download"></i> 导出</button>
-                            <label class="btn btn-sm" style="cursor:pointer;"><i class="fa-solid fa-upload"></i> 导入<input type="file" id="nd_char_import" accept=".json" style="display:none;"></label>
-                        </div>
-                        <div class="auto-learn-section" style="margin-bottom:12px;">
-                            <div class="auto-learn-toggle-row">
-                                <label class="toggle-switch">
-                                    <input type="checkbox" id="nd_auto_learn">
-                                    <span class="toggle-slider"></span>
-                                </label>
-                                <span>自动学习角色</span>
-                            </div>
-                            <div id="nd_auto_learn_sub" class="auto-learn-sub hidden">
-                                <label>
-                                    <input type="checkbox" id="nd_auto_learn_update"> 同时补全已有角色空白外貌
-                                </label>
-                            </div>
-                            <p class="form-hint" style="margin-left:44px;margin-top:4px;">生成图片时自动记住 LLM 识别的新角色</p>
-                        </div>
-                        <div class="auto-learn-section" style="margin-bottom:12px;">
-                            <div class="auto-learn-toggle-row">
-                                <label class="toggle-switch">
-                                    <input type="checkbox" id="nd_danbooru_local">
-                                    <span class="toggle-slider"></span>
-                                </label>
-                                <span>（测试）Danbooru 角色资源库</span>
-                            </div>
-                            <div id="nd_danbooru_local_sub" class="auto-learn-sub hidden">
-                                <span id="nd_danbooru_local_status" style="font-size:11px;color:var(--text-muted);">未加载</span>
-                            </div>
-                            <p class="form-hint" style="margin-left:44px;margin-top:4px;">启用后加载本地 Danbooru top 7000 角色库，支持离线搜索和自动修正 danbooruTag</p>
-                        </div>
-                        <div id="nd_char_list" class="char-grid"></div>
-                        <div id="nd_char_empty" class="char-empty">
-                            <i class="fa-solid fa-user-plus"></i>
-                            <div>暂无角色配置</div>
-                        </div>
-                    </div>
-                </div>
             </div>
 
             <!-- ═══════════════════════════════════════════════════════════════
@@ -950,6 +962,140 @@ body.advanced-mode .nd-simple-only { display: none !important; }
                         <input type="checkbox" id="nd_advanced_mode"> 高级模式
                     </label>
                     <p class="form-hint" style="margin-left:24px;margin-top:4px;">开启后可自定义提示词模板并精细配置世界书注入</p>
+                </div>
+            </div>
+
+            <!-- ═══════════════════════════════════════════════════════════════
+                 角色标签
+                 ═══════════════════════════════════════════════════════════════ -->
+            <div id="view-characters" class="view">
+                <div class="view-header">
+                    <h2 class="view-title">角色标签</h2>
+                    <p class="view-desc">集中管理角色外貌标签、自动学习与 Danbooru 资源库，PC 端支持双栏管理</p>
+                </div>
+
+                <div class="char-management-layout">
+                    <aside class="char-management-sidebar">
+                        <div class="card">
+                            <div class="card-title">📊 角色概览</div>
+                            <div class="char-summary-grid">
+                                <div class="char-summary-item">
+                                    <div class="char-summary-label">总角色数</div>
+                                    <div class="char-summary-value accent" id="nd_char_stat_total">0</div>
+                                </div>
+                                <div class="char-summary-item">
+                                    <div class="char-summary-label">已配置外貌</div>
+                                    <div class="char-summary-value" id="nd_char_stat_ready">0</div>
+                                </div>
+                                <div class="char-summary-item">
+                                    <div class="char-summary-label">待完善</div>
+                                    <div class="char-summary-value" id="nd_char_stat_missing">0</div>
+                                </div>
+                                <div class="char-summary-item">
+                                    <div class="char-summary-label">Danbooru 已绑定</div>
+                                    <div class="char-summary-value" id="nd_char_stat_danbooru">0</div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="card">
+                            <div class="card-title">🔎 搜索与筛选</div>
+                            <div class="form-group">
+                                <label class="form-label">关键词</label>
+                                <input id="nd_char_search" type="text" class="input" placeholder="搜索名称、别名、外貌、Danbooru 标签">
+                            </div>
+                            <div class="char-filter-row">
+                                <div class="form-group">
+                                    <label class="form-label">角色类型</label>
+                                    <select id="nd_char_filter_type" class="input">
+                                        <option value="all">全部类型</option>
+                                        <option value="girl">girl</option>
+                                        <option value="woman">woman</option>
+                                        <option value="boy">boy</option>
+                                        <option value="man">man</option>
+                                        <option value="other">other</option>
+                                        <option value="custom">自定义类型</option>
+                                    </select>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">状态筛选</label>
+                                    <select id="nd_char_filter_status" class="input">
+                                        <option value="all">全部状态</option>
+                                        <option value="complete">已配置外貌</option>
+                                        <option value="incomplete">待完善外貌</option>
+                                        <option value="danbooru">已绑定 Danbooru</option>
+                                        <option value="negative">含负向标签</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="btn-group">
+                                <button id="nd_char_filter_reset" class="btn btn-sm"><i class="fa-solid fa-rotate-left"></i> 重置筛选</button>
+                            </div>
+                            <div id="nd_char_filter_summary" class="char-filter-summary">当前显示全部角色</div>
+                        </div>
+
+                        <div class="card">
+                            <div class="card-title">🧰 批量操作</div>
+                            <div class="btn-group">
+                                <button id="nd_char_add" class="btn btn-primary btn-sm"><i class="fa-solid fa-plus"></i> 添加角色</button>
+                                <button id="nd_char_clear" class="btn btn-danger btn-sm"><i class="fa-solid fa-trash-can"></i> 清除全部</button>
+                                <button id="nd_char_export" class="btn btn-sm"><i class="fa-solid fa-download"></i> 导出</button>
+                                <label class="btn btn-sm" style="cursor:pointer;"><i class="fa-solid fa-upload"></i> 导入<input type="file" id="nd_char_import" accept=".json" style="display:none;"></label>
+                            </div>
+                        </div>
+
+                        <div class="card">
+                            <div class="card-title">🧠 智能辅助</div>
+                            <div class="auto-learn-section" style="margin-bottom:12px;">
+                                <div class="auto-learn-toggle-row">
+                                    <label class="toggle-switch">
+                                        <input type="checkbox" id="nd_auto_learn">
+                                        <span class="toggle-slider"></span>
+                                    </label>
+                                    <span>自动学习角色</span>
+                                </div>
+                                <div id="nd_auto_learn_sub" class="auto-learn-sub hidden">
+                                    <label>
+                                        <input type="checkbox" id="nd_auto_learn_update"> 同时补全已有角色空白外貌
+                                    </label>
+                                </div>
+                                <p class="form-hint" style="margin-left:44px;margin-top:4px;">生成图片时自动记住 LLM 识别的新角色</p>
+                            </div>
+                            <div class="auto-learn-section">
+                                <div class="auto-learn-toggle-row">
+                                    <label class="toggle-switch">
+                                        <input type="checkbox" id="nd_danbooru_local">
+                                        <span class="toggle-slider"></span>
+                                    </label>
+                                    <span>（测试）Danbooru 角色资源库</span>
+                                </div>
+                                <div id="nd_danbooru_local_sub" class="auto-learn-sub hidden">
+                                    <span id="nd_danbooru_local_status" style="font-size:11px;color:var(--text-muted);">未加载</span>
+                                </div>
+                                <p class="form-hint" style="margin-left:44px;margin-top:4px;">启用后加载本地 Danbooru top 7000 角色库，支持离线搜索和自动修正 danbooruTag</p>
+                            </div>
+                        </div>
+                    </aside>
+
+                    <section class="char-management-main">
+                        <div class="card char-list-card" id="nd_char_card">
+                            <div class="char-list-card-header">
+                                <div>
+                                    <div class="card-title">👥 角色列表</div>
+                                    <p class="form-hint" style="margin-top:6px;">预设角色外貌，LLM 只需补充动作和互动标签</p>
+                                </div>
+                                <div class="char-list-count" id="nd_char_result_count">0 / 0</div>
+                            </div>
+                            <div class="char-list-body">
+                                <div id="nd_char_list" class="char-grid"></div>
+                                <div id="nd_char_empty" class="char-empty">
+                                    <i class="fa-solid fa-user-plus"></i>
+                                    <strong>暂无角色配置</strong>
+                                    <p>点击左侧“添加角色”，开始建立你的角色标签库</p>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
                 </div>
             </div>
 
@@ -1117,6 +1263,7 @@ body.advanced-mode .nd-simple-only { display: none !important; }
             <div class="mobile-nav-item" data-view="api"><i class="fa-solid fa-key"></i><span>API</span></div>
             <div class="mobile-nav-item" data-view="params"><i class="fa-solid fa-sliders"></i><span>参数</span></div>
             <div class="mobile-nav-item" data-view="llm"><i class="fa-solid fa-robot"></i><span>LLM</span></div>
+            <div class="mobile-nav-item" data-view="characters"><i class="fa-solid fa-user-group"></i><span>角色</span></div>
             <div class="mobile-nav-item" data-view="gallery"><i class="fa-solid fa-images"></i><span>图片</span></div>
             <div class="mobile-nav-item nd-advanced-only" data-view="prompts"><i class="fa-solid fa-file-code"></i><span>提示词</span></div>
             <div class="mobile-nav-item nd-advanced-only" data-view="worldbook"><i class="fa-solid fa-book-atlas"></i><span>世界书</span></div>
@@ -1224,6 +1371,7 @@ let gallerySummary = {};
 let loadedCharPreviews = {};
 let editingCharId = null;
 const saveBtnStates = new WeakMap();
+let charFilters = { query: '', type: 'all', status: 'all' };
 let modalData = { slotId: null, images: [], currentIndex: 0, charName: null };
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1380,27 +1528,159 @@ function collectFilterRules() {
 // 角色列表
 // ═══════════════════════════════════════════════════════════════════════════
 
+function normalizeCharType(type) {
+    const knownTypes = new Set(CHARACTER_TYPES.filter(t => t.value !== 'custom').map(t => t.value));
+    return knownTypes.has(type) ? type : 'custom';
+}
+
+function getFilteredCharacters(chars = []) {
+    const query = String(charFilters.query || '').trim().toLowerCase();
+    const typeFilter = charFilters.type || 'all';
+    const statusFilter = charFilters.status || 'all';
+
+    return chars.filter(char => {
+        if (query) {
+            const haystack = [
+                char.name,
+                ...(char.aliases || []),
+                char.type,
+                char.appearance,
+                char.negativeTags,
+                char.danbooruTag,
+                ...((char.outfits || []).flatMap(outfit => [outfit?.name, outfit?.tags])),
+            ].filter(Boolean).join(' ').toLowerCase();
+
+            if (!haystack.includes(query)) return false;
+        }
+
+        if (typeFilter !== 'all' && normalizeCharType(char.type || 'girl') !== typeFilter) {
+            return false;
+        }
+
+        if (statusFilter === 'complete' && !char.appearance) return false;
+        if (statusFilter === 'incomplete' && !!char.appearance) return false;
+        if (statusFilter === 'danbooru' && !char.danbooruTag) return false;
+        if (statusFilter === 'negative' && !char.negativeTags) return false;
+
+        return true;
+    });
+}
+
+function updateCharacterPanelMeta(allChars, filteredChars) {
+    const readyCount = allChars.filter(char => !!char.appearance).length;
+    const missingCount = allChars.length - readyCount;
+    const danbooruCount = allChars.filter(char => !!char.danbooruTag).length;
+    const filtersActive = !!String(charFilters.query || '').trim() || charFilters.type !== 'all' || charFilters.status !== 'all';
+
+    $('nd_char_stat_total').textContent = String(allChars.length);
+    $('nd_char_stat_ready').textContent = String(readyCount);
+    $('nd_char_stat_missing').textContent = String(missingCount);
+    $('nd_char_stat_danbooru').textContent = String(danbooruCount);
+    $('nd_char_result_count').textContent = `${filteredChars.length} / ${allChars.length}`;
+    $('nd_char_filter_summary').textContent = filtersActive
+        ? `筛选结果：显示 ${filteredChars.length} / ${allChars.length} 个角色`
+        : `当前显示全部 ${allChars.length} 个角色`;
+}
+
+function resetCharacterFilters(render = true) {
+    charFilters = { query: '', type: 'all', status: 'all' };
+    if ($('nd_char_search')) $('nd_char_search').value = '';
+    if ($('nd_char_filter_type')) $('nd_char_filter_type').value = 'all';
+    if ($('nd_char_filter_status')) $('nd_char_filter_status').value = 'all';
+    if (render) renderCharList();
+}
+
+function normalizeCharacterOutfitsForUI(outfits = []) {
+    return (Array.isArray(outfits) ? outfits : [])
+        .map(outfit => ({
+            name: String(outfit?.name || '').trim(),
+            tags: String(outfit?.tags || '').trim(),
+        }))
+        .filter(outfit => outfit.name || outfit.tags);
+}
+
+function renderOutfitEditorItem(outfit = {}, index = 0) {
+    return `
+    <div class="char-outfit-editor-item" data-index="${index}">
+        <div class="char-outfit-editor-header">
+            <div class="char-outfit-editor-title">服装 ${index + 1}</div>
+            <button class="btn btn-danger btn-sm" type="button" data-action="remove-outfit" data-index="${index}"><i class="fa-solid fa-trash"></i> 删除</button>
+        </div>
+        <div class="form-group">
+            <label class="form-label">服装名称</label>
+            <input type="text" class="input char-outfit-name" value="${escapeHtml(outfit.name || '')}" placeholder="如：常服、礼服、战斗服">
+        </div>
+        <div class="form-group">
+            <label class="form-label">服装 TAG</label>
+            <textarea class="input char-outfit-tags" placeholder="white shirt, black skirt, ribbon...">${escapeHtml(outfit.tags || '')}</textarea>
+        </div>
+    </div>`;
+}
+
+function syncOutfitEditorList(list) {
+    if (!list) return;
+    const rows = Array.from(list.querySelectorAll('.char-outfit-editor-item'));
+    const empty = list.querySelector('.char-outfit-editor-empty');
+    if (empty) empty.style.display = rows.length ? 'none' : 'block';
+    rows.forEach((row, index) => {
+        row.dataset.index = String(index);
+        row.querySelector('.char-outfit-editor-title').textContent = `服装 ${index + 1}`;
+        const removeBtn = row.querySelector('[data-action="remove-outfit"]');
+        if (removeBtn) removeBtn.dataset.index = String(index);
+    });
+}
+
+function collectOutfitEditorValues(card) {
+    return Array.from(card.querySelectorAll('.char-outfit-editor-item')).map(row => ({
+        name: row.querySelector('.char-outfit-name')?.value?.trim() || '',
+        tags: row.querySelector('.char-outfit-tags')?.value?.trim() || '',
+    })).filter(outfit => outfit.name || outfit.tags);
+}
 
 function renderCharList() {
     const list = $('nd_char_list');
     const empty = $('nd_char_empty');
     const chars = state.characterTags || [];
+    const filteredChars = getFilteredCharacters(chars);
+
+    updateCharacterPanelMeta(chars, filteredChars);
     
     if (!chars.length) {
         list.innerHTML = '';
         list.style.display = 'none';
+        empty.classList.remove('filtered');
+        empty.innerHTML = `
+            <i class="fa-solid fa-user-plus"></i>
+            <strong>暂无角色配置</strong>
+            <p>点击左侧“添加角色”，开始建立你的角色标签库</p>
+        `;
+        empty.style.display = 'block';
+        return;
+    }
+
+    if (!filteredChars.length) {
+        list.innerHTML = '';
+        list.style.display = 'none';
+        empty.classList.add('filtered');
+        empty.innerHTML = `
+            <i class="fa-solid fa-filter-circle-xmark"></i>
+            <strong>没有匹配的角色</strong>
+            <p>试试调整搜索关键词或重置筛选条件</p>
+        `;
         empty.style.display = 'block';
         return;
     }
     
     list.style.display = 'flex';
     empty.style.display = 'none';
+    empty.classList.remove('filtered');
     
-    list.innerHTML = chars.map(c => {
+    list.innerHTML = filteredChars.map(c => {
         const isEditing = editingCharId === c.id;
         const typeLabel = CHARACTER_TYPES.find(t => t.value === c.type)?.label || c.type || 'girl';
         const typeShort = typeLabel.split(' ')[0];
         const appearance = c.appearance || '';
+        const outfits = normalizeCharacterOutfitsForUI(c.outfits);
 
         if (isEditing) {
             const typeOptions = CHARACTER_TYPES.map(t =>
@@ -1445,6 +1725,17 @@ function renderCharList() {
                         <label class="form-label">负向标签（可选）</label>
                         <textarea class="input char-edit-neg" placeholder="避免的特征...">${escapeHtml(c.negativeTags || '')}</textarea>
                     </div>
+                    <div class="form-group">
+                        <label class="form-label" style="display:flex;align-items:center;justify-content:space-between;gap:8px;">
+                            <span>服装列表（可选）</span>
+                            <button class="btn btn-sm" type="button" data-action="add-outfit" data-id="${c.id}"><i class="fa-solid fa-plus"></i> 添加服装</button>
+                        </label>
+                        <div class="char-outfit-editor-list">
+                            <div class="char-outfit-editor-empty"${outfits.length ? ' style="display:none;"' : ''}>未配置服装时可留空；添加后会在生图规划时作为服装参考发送给 AI。</div>
+                            ${outfits.map((outfit, index) => renderOutfitEditorItem(outfit, index)).join('')}
+                        </div>
+                        <p class="form-hint">示例：常服 / white shirt, pleated skirt；礼服 / evening dress, lace gloves</p>
+                    </div>
                     <div class="btn-group" style="margin-top:12px;">
                         <button class="btn btn-primary" data-action="save" data-id="${c.id}"><i class="fa-solid fa-check"></i> 保存</button>
                         <button class="btn" data-action="cancel" data-id="${c.id}">取消</button>
@@ -1458,6 +1749,7 @@ function renderCharList() {
         else statusParts.push('⚠️未设置');
         if (c.negativeTags) statusParts.push('❌neg');
         if (c.danbooruTag) statusParts.push('🏷️db');
+        if (outfits.length) statusParts.push(`👗${outfits.length}套`);
 
         return `
         <div class="char-card" data-id="${c.id}">
@@ -1480,14 +1772,26 @@ function renderCharList() {
             if (customInput) customInput.classList.toggle('hidden', this.value !== 'custom');
         });
     });
+
+    list.querySelectorAll('.char-outfit-editor-list').forEach(syncOutfitEditorList);
 }
 
-function handleCharAction(action, id, card) {
+function handleCharAction(action, id, card, trigger) {
     if (action === 'fix-danbooru' || action === 'search') {
         if (!state.danbooruLocalDB) { alert('请先启用 Danbooru 本地资源库'); return; }
         editingCharId = id;
         renderCharList();
         requestAnimationFrame(() => requestAnimationFrame(() => showLocalDanbooruFix(id)));
+    } else if (action === 'add-outfit') {
+        const list = card?.querySelector('.char-outfit-editor-list');
+        if (!list) return;
+        list.insertAdjacentHTML('beforeend', renderOutfitEditorItem({}, list.querySelectorAll('.char-outfit-editor-item').length));
+        syncOutfitEditorList(list);
+    } else if (action === 'remove-outfit') {
+        const row = trigger?.closest('.char-outfit-editor-item');
+        const list = row?.closest('.char-outfit-editor-list');
+        row?.remove();
+        syncOutfitEditorList(list);
     } else if (action === 'search-danbooru') {
         if (!state.danbooruLocalDB) { alert('请先启用 Danbooru 本地资源库'); return; }
         showLocalDanbooruFix(id);
@@ -1514,6 +1818,7 @@ function handleCharAction(action, id, card) {
         char.aliases = (card.querySelector('.char-edit-aliases')?.value || '').split(/[,，]/).map(s => s.trim()).filter(Boolean);
         char.appearance = card.querySelector('.char-edit-appearance')?.value?.trim() || '';
         char.negativeTags = card.querySelector('.char-edit-neg')?.value?.trim() || '';
+        char.outfits = collectOutfitEditorValues(card);
 
         editingCharId = null;
         postToParent({ type: 'SAVE_CHARACTER_TAGS', characterTags: state.characterTags });
@@ -2414,13 +2719,32 @@ document.addEventListener('DOMContentLoaded', () => {
     // ═══════════════════════════════════════════════════════════════════════
     // 角色标签
     // ═══════════════════════════════════════════════════════════════════════
-    $('nd_char_header').addEventListener('click', () => { $('nd_char_card').classList.toggle('collapsed'); });
+    $('nd_char_search').addEventListener('input', e => {
+        charFilters.query = e.target.value || '';
+        renderCharList();
+    });
+
+    $('nd_char_filter_type').addEventListener('change', e => {
+        charFilters.type = e.target.value || 'all';
+        renderCharList();
+    });
+
+    $('nd_char_filter_status').addEventListener('change', e => {
+        charFilters.status = e.target.value || 'all';
+        renderCharList();
+    });
+
+    $('nd_char_filter_reset').addEventListener('click', () => {
+        resetCharacterFilters();
+    });
     
     $('nd_char_add').addEventListener('click', () => {
-        const nc = { id: `char-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`, name: '', aliases: [], type: 'girl', appearance: '', negativeTags: '' };
+        const nc = { id: `char-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`, name: '', aliases: [], type: 'girl', appearance: '', negativeTags: '', outfits: [] };
         state.characterTags.push(nc);
         editingCharId = nc.id;
+        resetCharacterFilters(false);
         renderCharList();
+        switchView('characters');
         setTimeout(() => document.querySelector('.char-edit-name')?.focus(), 50);
     });
     
@@ -2429,7 +2753,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!btn) return;
         const card = btn.closest('.char-card');
         const id = btn.dataset.id || card?.dataset.id;
-        if (id) handleCharAction(btn.dataset.action, id, card);
+        if (id) handleCharAction(btn.dataset.action, id, card, btn);
     });
 
     // auto-learn (toggle + subordinate checkbox)
@@ -2465,7 +2789,7 @@ document.addEventListener('DOMContentLoaded', () => {
     
     $('nd_char_export').addEventListener('click', () => {
         if (!state.characterTags?.length) { alert('没有可导出的角色'); return; }
-        const d = { type: 'novel-draw-characters', version: 2, characters: state.characterTags };
+        const d = { type: 'novel-draw-characters', version: 3, characters: state.characterTags };
         const blob = new Blob([JSON.stringify(d, null, 2)], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');

--- a/modules/novel-draw/novel-draw.js
+++ b/modules/novel-draw/novel-draw.js
@@ -268,6 +268,97 @@ function ensureStyles() {
 
 function createPlaceholder(slotId) { return `[image:${slotId}]`; }
 
+function getNovelDrawSavedMap(message) {
+    const savedMap = message?.extra?.novelDrawSaved;
+    return savedMap && typeof savedMap === 'object' ? savedMap : null;
+}
+
+function getNovelDrawSavedEntry(message, slotId) {
+    if (!slotId) return null;
+    return getNovelDrawSavedMap(message)?.[slotId] || null;
+}
+
+function normalizeNovelDrawSavedEntry(slotId, data = {}) {
+    if (!slotId || !data?.savedUrl) return null;
+    return {
+        slotId,
+        imgId: data.imgId || '',
+        savedUrl: data.savedUrl,
+        tags: data.tags || '',
+        positive: data.positive || '',
+        anchor: data.anchor || '',
+        updatedAt: Date.now(),
+    };
+}
+
+async function persistChatSilently() {
+    const ctx = getContext();
+    if (!ctx?.saveChat) return;
+    await Promise.resolve(ctx.saveChat());
+}
+
+async function setNovelDrawSavedEntry(messageId, slotId, data) {
+    const ctx = getContext();
+    const message = ctx.chat?.[messageId];
+    const entry = normalizeNovelDrawSavedEntry(slotId, data);
+    if (!message || !entry) return false;
+
+    message.extra ||= {};
+    message.extra.novelDrawSaved ||= {};
+
+    const previous = message.extra.novelDrawSaved[slotId];
+    const unchanged = previous &&
+        previous.imgId === entry.imgId &&
+        previous.savedUrl === entry.savedUrl &&
+        previous.tags === entry.tags &&
+        previous.positive === entry.positive &&
+        previous.anchor === entry.anchor;
+    if (unchanged) return true;
+
+    message.extra.novelDrawSaved[slotId] = entry;
+    await persistChatSilently();
+    return true;
+}
+
+async function clearNovelDrawSavedEntry(messageId, slotId) {
+    const ctx = getContext();
+    const message = ctx.chat?.[messageId];
+    const savedMap = getNovelDrawSavedMap(message);
+    if (!message || !savedMap?.[slotId]) return false;
+
+    delete savedMap[slotId];
+    if (Object.keys(savedMap).length === 0 && message.extra) {
+        delete message.extra.novelDrawSaved;
+    }
+
+    await persistChatSilently();
+    return true;
+}
+
+async function syncNovelDrawSavedFromPreview(messageId, preview, overrides = {}) {
+    const slotId = overrides.slotId || preview?.slotId;
+    if (!slotId) return false;
+
+    return setNovelDrawSavedEntry(messageId, slotId, {
+        imgId: overrides.imgId || preview?.imgId,
+        savedUrl: overrides.savedUrl || preview?.savedUrl,
+        tags: overrides.tags ?? preview?.tags ?? '',
+        positive: overrides.positive ?? preview?.positive ?? '',
+        anchor: overrides.anchor ?? preview?.anchor ?? '',
+    });
+}
+
+async function syncNovelDrawSavedAfterDeletion(messageId, slotId, deletedImgId, remainingPreviews = []) {
+    const message = getContext().chat?.[messageId];
+    const currentSaved = getNovelDrawSavedEntry(message, slotId);
+    if (!currentSaved) return false;
+    if (deletedImgId && currentSaved.imgId && currentSaved.imgId !== deletedImgId) return false;
+
+    const replacement = remainingPreviews.find(item => item?.savedUrl);
+    if (replacement) return syncNovelDrawSavedFromPreview(messageId, replacement, { slotId });
+    return clearNovelDrawSavedEntry(messageId, slotId);
+}
+
 function extractSlotIds(mes) {
     const ids = new Set();
     if (!mes) return ids;
@@ -329,6 +420,261 @@ function isMessageBeingEdited(messageId) {
     const mesElement = document.querySelector(`.mes[mesid="${messageId}"]`);
     if (!mesElement) return false;
     return mesElement.querySelector('textarea.edit_textarea') !== null || mesElement.classList.contains('editing');
+}
+
+function getMesTextElement(messageId) {
+    if (!Number.isFinite(messageId)) return null;
+    return document.querySelector(`#chat .mes[mesid="${messageId}"] .mes_text`);
+}
+
+function createNodeFromHtml(html) {
+    const template = document.createElement('template');
+    template.innerHTML = String(html || '').trim();
+    return template.content.firstElementChild || null;
+}
+
+function getTrimmedText(value) {
+    return String(value || '').replace(/\u200B/g, '').trim();
+}
+
+function findTopLevelFlowContainer(root, node) {
+    let current = node?.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+    while (current && current.parentElement && current.parentElement !== root) {
+        current = current.parentElement;
+    }
+    return current && current.parentElement === root ? current : null;
+}
+
+function insertAfterFlowContainer(target, node) {
+    if (!target?.parentElement || !node) return false;
+    let ref = target;
+    while (ref.nextElementSibling?.classList?.contains('xb-nd-img')) {
+        ref = ref.nextElementSibling;
+    }
+    ref.insertAdjacentElement('afterend', node);
+    return true;
+}
+
+function removeIfEmptyFlowContainer(container) {
+    if (!(container instanceof HTMLElement)) return;
+    if (!['P', 'DIV', 'BLOCKQUOTE', 'LI'].includes(container.tagName)) return;
+    if (container.querySelector('img, video, audio, canvas, iframe, .xb-nd-img')) return;
+    if (getTrimmedText(container.textContent).length > 0) return;
+    container.remove();
+}
+
+function replacePlaceholdersInDomBatch(root, replacements) {
+    if (!root || !Array.isArray(replacements) || replacements.length === 0) return new Set();
+
+    const pending = replacements.filter(item =>
+        item?.slotId &&
+        item?.html &&
+        !root.querySelector(`.xb-nd-img[data-slot-id="${item.slotId}"]`)
+    );
+    if (pending.length === 0) return new Set();
+
+    const placeholderMap = new Map(pending.map(item => [createPlaceholder(item.slotId), item]));
+    const placeholderRegex = new RegExp(
+        Array.from(placeholderMap.keys()).map(escapeRegexChars).join('|'),
+        'g'
+    );
+    const resolvedSlotIds = new Set();
+    const nodePlans = new Map();
+    const groupedByContainer = new Map();
+    const orderedContainers = [];
+
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+        acceptNode(node) {
+            return node.parentElement?.closest('.xb-nd-img')
+                ? NodeFilter.FILTER_REJECT
+                : NodeFilter.FILTER_ACCEPT;
+        }
+    });
+
+    let textNode;
+    while ((textNode = walker.nextNode())) {
+        const value = textNode.nodeValue || '';
+        placeholderRegex.lastIndex = 0;
+        let match;
+        while ((match = placeholderRegex.exec(value))) {
+            const placeholder = match[0];
+            const patch = placeholderMap.get(placeholder);
+            if (!patch || resolvedSlotIds.has(patch.slotId)) continue;
+
+            const container = findTopLevelFlowContainer(root, textNode) || root;
+            if (!groupedByContainer.has(container)) {
+                groupedByContainer.set(container, []);
+                orderedContainers.push(container);
+            }
+            groupedByContainer.get(container).push(patch);
+
+            if (!nodePlans.has(textNode)) {
+                nodePlans.set(textNode, { text: value, removals: [] });
+            }
+            nodePlans.get(textNode).removals.push({ start: match.index, end: match.index + placeholder.length });
+            resolvedSlotIds.add(patch.slotId);
+        }
+    }
+
+    nodePlans.forEach((plan, node) => {
+        let nextText = plan.text;
+        plan.removals
+            .sort((a, b) => b.start - a.start)
+            .forEach(removal => {
+                nextText = nextText.slice(0, removal.start) + nextText.slice(removal.end);
+            });
+
+        if (nextText) node.nodeValue = nextText;
+        else node.remove();
+    });
+
+    orderedContainers.forEach(container => {
+        const patches = groupedByContainer.get(container) || [];
+        let ref = container;
+        patches.forEach(patch => {
+            const node = createNodeFromHtml(patch.html);
+            if (!node) return;
+
+            if (container === root) {
+                root.appendChild(node);
+                ref = node;
+                return;
+            }
+
+            ref.insertAdjacentElement('afterend', node);
+            ref = node;
+        });
+
+        if (container !== root) removeIfEmptyFlowContainer(container);
+    });
+
+    return resolvedSlotIds;
+}
+
+function replacePlaceholderTextInDom(root, placeholder, html) {
+    if (!root || !placeholder) return false;
+
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+        acceptNode(node) {
+            if (node.parentElement?.closest('.xb-nd-img')) return NodeFilter.FILTER_REJECT;
+            return node.nodeValue?.includes(placeholder) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+        }
+    });
+
+    const textNode = walker.nextNode();
+    if (!textNode) return false;
+
+    const replacementNode = createNodeFromHtml(html);
+    if (!replacementNode) return false;
+
+    const index = textNode.nodeValue.indexOf(placeholder);
+    if (index < 0) return false;
+
+    const beforeText = textNode.nodeValue.slice(0, index);
+    const afterText = textNode.nodeValue.slice(index + placeholder.length);
+    const topLevelContainer = findTopLevelFlowContainer(root, textNode);
+
+    textNode.nodeValue = beforeText;
+    if (afterText) {
+        textNode.parentNode?.insertBefore(document.createTextNode(afterText), textNode.nextSibling);
+    }
+    if (!beforeText) {
+        textNode.remove();
+    }
+
+    if (topLevelContainer) {
+        insertAfterFlowContainer(topLevelContainer, replacementNode);
+        removeIfEmptyFlowContainer(topLevelContainer);
+        return true;
+    }
+
+    root.appendChild(replacementNode);
+    return true;
+}
+
+function collectRenderedTextSegments(root) {
+    const segments = [];
+    let text = '';
+
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, {
+        acceptNode(node) {
+            if (node.nodeType === Node.ELEMENT_NODE) {
+                const el = node;
+                if (el.classList?.contains('xb-nd-img')) return NodeFilter.FILTER_REJECT;
+                if (el.tagName === 'SCRIPT' || el.tagName === 'STYLE') return NodeFilter.FILTER_REJECT;
+                if (el.tagName === 'BR') return NodeFilter.FILTER_ACCEPT;
+                return NodeFilter.FILTER_SKIP;
+            }
+            return node.parentElement?.closest('.xb-nd-img')
+                ? NodeFilter.FILTER_REJECT
+                : NodeFilter.FILTER_ACCEPT;
+        }
+    });
+
+    let node;
+    while ((node = walker.nextNode())) {
+        const chunk = node.nodeType === Node.TEXT_NODE ? node.nodeValue : '\n';
+        if (!chunk) continue;
+        const start = text.length;
+        text += chunk;
+        segments.push({ node, start, end: text.length, text: chunk });
+    }
+
+    return { text, segments };
+}
+
+function insertPreviewByAnchor(root, slotId, anchor, html) {
+    if (!root || !slotId || !anchor) return false;
+    if (root.querySelector(`.xb-nd-img[data-slot-id="${slotId}"]`)) return true;
+
+    const { text, segments } = collectRenderedTextSegments(root);
+    if (!text || !segments.length) return false;
+
+    let position = findAnchorPosition(text, anchor);
+    if (position < 0) return false;
+    position = findNearestSentenceEnd(text, position);
+
+    const segment = segments.find(item => item.end >= position) || segments[segments.length - 1];
+    const replacementNode = createNodeFromHtml(html);
+    if (!segment || !replacementNode) return false;
+
+    const topLevelContainer = findTopLevelFlowContainer(root, segment.node);
+    if (topLevelContainer) {
+        return insertAfterFlowContainer(topLevelContainer, replacementNode);
+    }
+
+    root.appendChild(replacementNode);
+    return true;
+}
+
+function insertPreviewBatchIntoRenderedMessage({ messageId, patches }) {
+    const mesTextEl = getMesTextElement(messageId);
+    if (!mesTextEl || !Array.isArray(patches) || patches.length === 0) return false;
+
+    const insertedSlotIds = replacePlaceholdersInDomBatch(mesTextEl, patches);
+    let inserted = insertedSlotIds.size > 0;
+
+    patches.forEach(patch => {
+        if (!patch?.slotId || !patch?.html || insertedSlotIds.has(patch.slotId)) return;
+        if (mesTextEl.querySelector(`.xb-nd-img[data-slot-id="${patch.slotId}"]`)) {
+            inserted = true;
+            return;
+        }
+
+        if (insertPreviewByAnchor(mesTextEl, patch.slotId, patch.anchor || '', patch.html)) {
+            inserted = true;
+        }
+    });
+
+    return inserted;
+}
+
+function insertPreviewIntoRenderedMessage({ messageId, slotId, html, anchor = '' }) {
+    return insertPreviewBatchIntoRenderedMessage({
+        messageId,
+        patches: [{ slotId, html, anchor }],
+    });
+
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1232,7 +1578,7 @@ async function navigateToImage(container, targetIndex) {
     if (targetIndex < 0 || targetIndex >= historyCount || targetIndex === currentIndex) return;
 
     const previews = await getPreviewsBySlot(slotId);
-    const successPreviews = previews.filter(p => p.status !== 'failed' && p.base64);
+    const successPreviews = previews.filter(p => p.status !== 'failed' && (p.base64 || p.savedUrl));
     if (targetIndex >= successPreviews.length) return;
 
     const targetPreview = successPreviews[targetIndex];
@@ -1256,6 +1602,10 @@ async function navigateToImage(container, targetIndex) {
     setImageState(container, targetPreview.savedUrl ? ImageState.SAVED : ImageState.PREVIEW);
     updateNavControls(container, targetIndex, historyCount);
     await setSlotSelection(slotId, targetPreview.imgId);
+    if (targetPreview.savedUrl) {
+        const messageId = parseInt(container.dataset.mesid);
+        void syncNovelDrawSavedFromPreview(messageId, targetPreview, { slotId }).catch(() => {});
+    }
 
     imgEl.classList.remove(`sliding-${direction}`);
     imgEl.classList.add(`sliding-in-${direction === 'left' ? 'left' : 'right'}`);
@@ -1460,6 +1810,9 @@ async function handleImageClick(container) {
                 cont.dataset.currentIndex = '0';
                 cont.dataset.historyCount = String(historyCount);
             }
+            if (selected?.savedUrl) {
+                void syncNovelDrawSavedFromPreview(msgId, selected, { slotId: sid }).catch(() => {});
+            }
         },
         onSave: (imgId, url) => {
             const cont = document.querySelector(`.xb-nd-img[data-img-id="${imgId}"]`);
@@ -1467,6 +1820,11 @@ async function handleImageClick(container) {
                 cont.querySelector('img').src = url;
                 setImageState(cont, ImageState.SAVED);
             }
+            void getPreview(imgId)
+                .then(preview => preview && syncNovelDrawSavedFromPreview(messageId, preview, { savedUrl: url }))
+                .catch(e => {
+                    console.warn('[NovelDraw] 保存后的楼层持久化失败:', e);
+                });
         },
         onDelete: async (sid, deletedImgId, remainingPreviews) => {
             const cont = document.querySelector(`.xb-nd-img[data-slot-id="${sid}"]`);
@@ -1480,6 +1838,7 @@ async function handleImageClick(container) {
                 cont.dataset.historyCount = String(remainingPreviews.length);
                 updateNavControls(cont, 0, remainingPreviews.length);
             }
+            void syncNovelDrawSavedAfterDeletion(messageId, sid, deletedImgId, remainingPreviews).catch(() => {});
         },
         onBecameEmpty: (sid, msgId, lastImageInfo) => {
             const cont = document.querySelector(`.xb-nd-img[data-slot-id="${sid}"]`);
@@ -1495,6 +1854,7 @@ async function handleImageClick(container) {
             // Template-only UI markup built locally.
             // eslint-disable-next-line no-unsanitized/property
             cont.outerHTML = failedHtml;
+            void clearNovelDrawSavedEntry(msgId, sid).catch(() => {});
         },
     });
 }
@@ -1636,7 +1996,12 @@ async function saveEditedTags(container) {
             savedUrl: originalPreview.savedUrl,
             characterPrompts: newCharPrompts || originalPreview.characterPrompts,
             negativePrompt: originalPreview.negativePrompt,
+            anchor: originalPreview.anchor || '',
         });
+
+        if (originalPreview.savedUrl) {
+            await syncNovelDrawSavedFromPreview(messageId, { ...originalPreview, tags: newSceneTags, positive: newPositive }, { slotId: originalPreview.slotId || slotId });
+        }
 
         container.dataset.positive = escapeHtml(newPositive);
     }
@@ -1674,6 +2039,7 @@ async function refreshSingleImage(container) {
 
         let characterPrompts = null;
         let negativePrompt = preset.negativePrefix || '';
+        let anchor = '';
 
         if (currentImgId) {
             const existingPreview = await getPreview(currentImgId);
@@ -1683,6 +2049,7 @@ async function refreshSingleImage(container) {
             if (existingPreview?.negativePrompt) {
                 negativePrompt = existingPreview.negativePrompt;
             }
+            anchor = existingPreview?.anchor || '';
         }
 
         if (!characterPrompts) {
@@ -1715,6 +2082,7 @@ async function refreshSingleImage(container) {
             positive: scene,
             characterPrompts,
             negativePrompt,
+            anchor,
         });
         await setSlotSelection(slotId, newImgId);
 
@@ -1725,7 +2093,7 @@ async function refreshSingleImage(container) {
         setImageState(container, ImageState.PREVIEW);
 
         const previews = await getPreviewsBySlot(slotId);
-        const successPreviews = previews.filter(p => p.status !== 'failed' && p.base64);
+        const successPreviews = previews.filter(p => p.status !== 'failed' && (p.base64 || p.savedUrl));
         container.dataset.historyCount = String(successPreviews.length);
         updateNavControls(container, 0, successPreviews.length);
 
@@ -1742,16 +2110,20 @@ async function saveSingleImage(container) {
     const slotId = container.dataset.slotId;
     const currentState = container.dataset.state;
     if (currentState !== ImageState.PREVIEW) return;
+    const messageId = parseInt(container.dataset.mesid);
     const preview = await getPreview(imgId);
     if (!preview?.base64) { alert('图片数据丢失，请刷新'); return; }
     setImageState(container, ImageState.SAVING);
     try {
         const charName = preview.characterName || getChatCharacterName();
         const url = await saveBase64AsFile(preview.base64, charName, `novel_${imgId}`, 'png');
+        preview.savedUrl = url;
         await updatePreviewSavedUrl(imgId, url);
         await setSlotSelection(slotId, imgId);
+        await syncNovelDrawSavedFromPreview(messageId, preview, { slotId, savedUrl: url });
         container.querySelector('img').src = url;
         setImageState(container, ImageState.SAVED);
+        container.dataset.imgId = preview.imgId;
         showToast(`已保存到: ${url}`, 'success', 5000);
     } catch (e) {
         console.error('[NovelDraw] 保存失败:', e);
@@ -1772,7 +2144,7 @@ async function deleteCurrentImage(container) {
     try {
         await deletePreview(imgId);
         const previews = await getPreviewsBySlot(slotId);
-        const successPreviews = previews.filter(p => p.status !== 'failed' && p.base64);
+        const successPreviews = previews.filter(p => p.status !== 'failed' && (p.base64 || p.savedUrl));
 
         if (successPreviews.length > 0) {
             const latest = successPreviews[0];
@@ -1785,9 +2157,11 @@ async function deleteCurrentImage(container) {
             container.dataset.historyCount = String(successPreviews.length);
             setImageState(container, latest.savedUrl ? ImageState.SAVED : ImageState.PREVIEW);
             updateNavControls(container, 0, successPreviews.length);
+            await syncNovelDrawSavedAfterDeletion(messageId, slotId, imgId, successPreviews);
             showToast(`已删除（剩余 ${successPreviews.length} 张）`);
         } else {
             await clearSlotSelection(slotId);
+            await clearNovelDrawSavedEntry(messageId, slotId);
             const failedHtml = buildFailedPlaceholderHtml({
                 slotId,
                 messageId,
@@ -1858,6 +2232,7 @@ async function retryFailedImage(container) {
             positive: scene,
             characterPrompts,
             negativePrompt,
+            anchor: latestFailed?.anchor || '',
         });
         await deleteFailedRecordsForSlot(slotId);
         await setSlotSelection(slotId, newImgId);
@@ -1886,6 +2261,7 @@ async function retryFailedImage(container) {
             tags: tags || '',
             positive: container.dataset.positive || '',
             errorType: errorType.code,
+            anchor: latestFailed?.anchor || '',
             errorMessage: errorType.desc
         });
         // Template-only UI markup built locally.
@@ -1920,10 +2296,12 @@ async function removePlaceholder(container) {
     if (!confirm('确定移除此占位符？')) return;
     await deleteFailedRecordsForSlot(slotId);
     await clearSlotSelection(slotId);
+    await clearNovelDrawSavedEntry(messageId, slotId);
     const ctx = getContext();
     const message = ctx.chat?.[messageId];
     if (message) message.mes = message.mes.replace(createPlaceholder(slotId), '');
     container.remove();
+    await persistChatSilently();
     showToast('占位符已移除');
 }
 
@@ -1958,6 +2336,37 @@ function observeMessageForLazyRender(messageId) {
 // 预览渲染
 // ═══════════════════════════════════════════════════════════════════════════
 
+async function resolveRenderPreviewForSlot(message, messageId, slotId) {
+    const savedEntry = getNovelDrawSavedEntry(message, slotId);
+    if (savedEntry?.savedUrl) {
+        const previews = await getPreviewsBySlot(slotId).catch(() => []);
+        const successPreviews = previews.filter(p => p.status !== 'failed' && (p.base64 || p.savedUrl));
+        const selectedIndex = successPreviews.findIndex(p => p.imgId === savedEntry.imgId);
+        const matchedPreview = selectedIndex >= 0 ? successPreviews[selectedIndex] : null;
+
+        return {
+            preview: {
+                ...matchedPreview,
+                slotId,
+                imgId: savedEntry.imgId || matchedPreview?.imgId || `saved-${slotId}`,
+                savedUrl: savedEntry.savedUrl,
+                tags: savedEntry.tags ?? matchedPreview?.tags ?? '',
+                positive: savedEntry.positive ?? matchedPreview?.positive ?? '',
+                anchor: savedEntry.anchor ?? matchedPreview?.anchor ?? '',
+                messageId,
+            },
+            historyCount: selectedIndex >= 0 ? successPreviews.length : 1,
+            currentIndex: selectedIndex >= 0 ? selectedIndex : 0,
+            hasData: true,
+            isFailed: false,
+            source: 'message-extra',
+        };
+    }
+
+    const displayData = await getDisplayPreviewForSlot(slotId);
+    return { ...displayData, currentIndex: 0, source: 'gallery-cache' };
+}
+
 async function renderPreviewsForMessage(messageId) {
     const ctx = getContext();
     const message = ctx.chat?.[messageId];
@@ -1966,23 +2375,20 @@ async function renderPreviewsForMessage(messageId) {
     const slotIds = extractSlotIds(message.mes);
     if (slotIds.size === 0) return;
 
-    const $mesText = $(`#chat .mes[mesid="${messageId}"] .mes_text`);
-    if (!$mesText.length) return;
+    const mesTextEl = getMesTextElement(messageId);
+    if (!mesTextEl) return;
 
-    let html = $mesText.html();
-    let replaced = false;
+    const replacements = [];
 
     for (const slotId of slotIds) {
-        if (html.includes(`data-slot-id="${slotId}"`)) continue;
-
-        const placeholder = createPlaceholder(slotId);
-        const escapedPlaceholder = placeholder.replace(/[[\]]/g, '\\$&');
-        if (!new RegExp(escapedPlaceholder).test(html)) continue;
+        if (mesTextEl.querySelector(`.xb-nd-img[data-slot-id="${slotId}"]`)) continue;
 
         let replacementHtml;
+        let anchor = '';
 
         try {
-            const displayData = await getDisplayPreviewForSlot(slotId);
+            const displayData = await resolveRenderPreviewForSlot(message, messageId, slotId);
+            anchor = displayData.preview?.anchor || '';
 
             if (displayData.isFailed) {
                 replacementHtml = buildFailedPlaceholderHtml({
@@ -2004,7 +2410,7 @@ async function renderPreviewsForMessage(messageId) {
                     messageId,
                     state: displayData.preview.savedUrl ? ImageState.SAVED : ImageState.PREVIEW,
                     historyCount: displayData.historyCount,
-                    currentIndex: 0
+                    currentIndex: displayData.currentIndex ?? 0
                 });
             } else {
                 replacementHtml = buildFailedPlaceholderHtml({
@@ -2028,12 +2434,38 @@ async function renderPreviewsForMessage(messageId) {
             });
         }
 
-        html = html.replace(new RegExp(escapedPlaceholder, 'g'), replacementHtml);
-        replaced = true;
+        replacements.push({ slotId, html: replacementHtml, anchor });
     }
 
-    if (replaced && !isMessageBeingEdited(messageId)) {
-        $mesText.html(html);
+    if (replacements.length === 0) return;
+
+    const insertedSlotIds = replacePlaceholdersInDomBatch(mesTextEl, replacements);
+    const pendingFallback = replacements.filter(item => !insertedSlotIds.has(item.slotId));
+    if (pendingFallback.length === 0) return;
+
+    let html = mesTextEl.innerHTML;
+    let fallbackReplaced = false;
+
+    for (const item of pendingFallback) {
+        const placeholder = createPlaceholder(item.slotId);
+        const escapedPlaceholder = placeholder.replace(/[[\]]/g, '\\$&');
+        if (!new RegExp(escapedPlaceholder).test(html)) continue;
+
+        html = html.replace(new RegExp(escapedPlaceholder, 'g'), item.html);
+        fallbackReplaced = true;
+    }
+
+    let anchorInserted = false;
+    if (!fallbackReplaced) {
+        pendingFallback.forEach(item => {
+            if (insertPreviewByAnchor(mesTextEl, item.slotId, item.anchor || '', item.html)) {
+                anchorInserted = true;
+            }
+        });
+    }
+
+    if (fallbackReplaced && !anchorInserted && !isMessageBeingEdited(messageId)) {
+        mesTextEl.innerHTML = html;
     }
 }
 
@@ -2207,6 +2639,7 @@ async function generateAndInsertImages({ messageId, onStateChange, skipLock = fa
         const results = [];
         const { messageFormatting } = await import('../../../../../../script.js');
         let successCount = 0;
+        let requiresFinalDomSync = false;
 
         for (let i = 0; i < tasks.length; i++) {
             if (signal.aborted) {
@@ -2235,6 +2668,7 @@ async function generateAndInsertImages({ messageId, onStateChange, skipLock = fa
             const scene = joinTags(preset.positivePrefix, task.scene);
             const characterPrompts = assembleCharacterPrompts(task.chars, settings.characterTags || []);
             const tagsForStore = task.scene;
+            let incrementalHtml = '';
 
             try {
                 const base64 = await generateNovelImage({
@@ -2253,10 +2687,22 @@ async function generateAndInsertImages({ messageId, onStateChange, skipLock = fa
                     tags: tagsForStore,
                     positive: scene,
                     characterPrompts,
-                    negativePrompt: preset.negativePrefix
+                    negativePrompt: preset.negativePrefix,
+                    anchor: task.anchor,
                 });
                 await setSlotSelection(slotId, imgId);
                 results.push({ slotId, imgId, tags: tagsForStore, success: true });
+                incrementalHtml = buildImageHtml({
+                    slotId,
+                    imgId,
+                    url: `data:image/png;base64,${base64}`,
+                    tags: tagsForStore,
+                    positive: scene,
+                    messageId,
+                    state: ImageState.PREVIEW,
+                    historyCount: 1,
+                    currentIndex: 0,
+                });
                 successCount++;
             } catch (e) {
                 if (signal.aborted) {
@@ -2274,8 +2720,17 @@ async function generateAndInsertImages({ messageId, onStateChange, skipLock = fa
                     errorMessage: errorType.desc,
                     characterPrompts,
                     negativePrompt: preset.negativePrefix,
+                    anchor: task.anchor,
                 });
                 results.push({ slotId, tags: tagsForStore, success: false, error: errorType });
+                incrementalHtml = buildFailedPlaceholderHtml({
+                    slotId,
+                    messageId,
+                    tags: tagsForStore,
+                    positive: scene,
+                    errorType: errorType.label,
+                    errorMessage: errorType.desc
+                });
             }
 
             if (signal.aborted) break;
@@ -2301,18 +2756,28 @@ async function generateAndInsertImages({ messageId, onStateChange, skipLock = fa
                 message.mes += (needNewline ? '\n' : '') + placeholder;
             }
 
-            if (signal.aborted) break;
 
             // ── 增量渲染：每张图完成后立即显示 ──
             try {
                 const incCtx = getContext();
                 const incMsg = incCtx.chat?.[messageId];
                 if (incCtx.chatId === initialChatId && incMsg === message && !isMessageBeingEdited(messageId)) {
-                    const formatted = messageFormatting(message.mes, message.name, message.is_system, message.is_user, messageId);
-                    $(`[mesid="${messageId}"] .mes_text`).html(formatted);
-                    await renderPreviewsForMessage(messageId);
+                    const inserted = insertPreviewIntoRenderedMessage({
+                        messageId,
+                        slotId,
+                        html: incrementalHtml,
+                        anchor: task.anchor,
+                    });
+
+                    if (!inserted) {
+                        requiresFinalDomSync = true;
+                        const formatted = messageFormatting(message.mes, message.name, message.is_system, message.is_user, messageId);
+                        $(`[mesid="${messageId}"] .mes_text`).html(formatted);
+                        await renderPreviewsForMessage(messageId);
+                    }
                 }
             } catch (e) {
+                requiresFinalDomSync = true;
                 console.warn('[NovelDraw] 增量渲染失败, 继续生成:', e);
             }
 
@@ -2339,13 +2804,15 @@ async function generateAndInsertImages({ messageId, onStateChange, skipLock = fa
 
             if (abortMsgValid && !isMessageBeingEdited(messageId)) {
                 try {
-                    const formatted = messageFormatting(message.mes, message.name, message.is_system, message.is_user, messageId);
-                    $(`[mesid="${messageId}"] .mes_text`).html(formatted);
-                    await renderPreviewsForMessage(messageId);
+                    if (successCount === 0 || requiresFinalDomSync) {
+                        const formatted = messageFormatting(message.mes, message.name, message.is_system, message.is_user, messageId);
+                        $(`[mesid="${messageId}"] .mes_text`).html(formatted);
+                        await renderPreviewsForMessage(messageId);
+                    }
                 } catch (e) {
                     console.warn('[NovelDraw] abort DOM 同步失败:', e);
                 }
-                abortCtx.saveChat?.().catch(() => {});
+                persistChatSilently().catch(() => {});
             }
 
             onStateChange?.('success', { success: successCount, total: tasks.length, aborted: true });
@@ -2357,7 +2824,7 @@ async function generateAndInsertImages({ messageId, onStateChange, skipLock = fa
             finalCtx.chat?.[messageId] === message &&
             !isMessageBeingEdited(messageId);
 
-        if (shouldUpdateDom) {
+        if (shouldUpdateDom && requiresFinalDomSync) {
             const formatted = messageFormatting(
                 message.mes,
                 message.name,
@@ -2373,6 +2840,8 @@ async function generateAndInsertImages({ messageId, onStateChange, skipLock = fa
                 const { processMessageById } = await import('../iframe-renderer.js');
                 processMessageById(messageId, true);
             } catch {}
+        } else if (shouldUpdateDom) {
+            console.log('[NovelDraw] 已跳过最终 full rerender，仅后台保存正文与局部 DOM patch');
         }
 
         const resultColor = successCount === tasks.length ? '#3ecf8e' : '#f0b429';
@@ -2381,7 +2850,7 @@ async function generateAndInsertImages({ messageId, onStateChange, skipLock = fa
         onStateChange?.('success', { success: successCount, total: tasks.length });
 
         if (shouldUpdateDom) {
-            getContext().saveChat?.().then(() => {
+            persistChatSilently().then(() => {
                 console.log('[NovelDraw] 聊天已保存');
             }).catch(e => {
                 console.warn('[NovelDraw] 保存聊天失败:', e);
@@ -3093,7 +3562,7 @@ async function handleFrameMessage(event) {
             const s = getSettings();
             const n = await clearExpiredCache(s.cacheDays || 3);
             sendInitData();
-            postStatus('success', `已清理 ${n} 张`);
+            postStatus('success', `已清理/瘦身 ${n} 条`);
             break;
         }
 
@@ -3129,7 +3598,9 @@ async function handleFrameMessage(event) {
                 }
                 const charName = preview.characterName || getChatCharacterName();
                 const url = await saveBase64AsFile(preview.base64, charName, `novel_${data.imgId}`, 'png');
+                preview.savedUrl = url;
                 await updatePreviewSavedUrl(data.imgId, url);
+                if (Number.isFinite(preview.messageId)) await syncNovelDrawSavedFromPreview(preview.messageId, preview, { savedUrl: url });
                 {
                     const iframe = document.getElementById('xiaobaix-novel-draw-iframe');
                     if (iframe) postToIframe(iframe, { type: 'GALLERY_IMAGE_SAVED', imgId: data.imgId, savedUrl: url }, 'LittleWhiteBox-NovelDraw');

--- a/modules/novel-draw/novel-draw.js
+++ b/modules/novel-draw/novel-draw.js
@@ -776,6 +776,7 @@ function normalizeSettings(saved) {
         appearance: char.appearance || char.tags || '',
         negativeTags: char.negativeTags || '',
         danbooruTag: char.danbooruTag || '',
+        outfits: normalizeCharacterOutfits(char.outfits || char.costumes || char.clothes || []),
     }));
 
     merged.autoLearnCharacters = !!merged.autoLearnCharacters;
@@ -1023,6 +1024,32 @@ async function extractImageFromZip(zipData) {
 // 角色检测与标签组装
 // ═══════════════════════════════════════════════════════════════════════════
 
+function normalizeCharacterOutfits(outfits = []) {
+    return (Array.isArray(outfits) ? outfits : [])
+        .map(outfit => ({
+            name: String(outfit?.name || '').trim(),
+            tags: String(outfit?.tags || '').trim(),
+        }))
+        .filter(outfit => outfit.name || outfit.tags);
+}
+
+function buildCharacterOutfitReference(outfits = []) {
+    const normalized = normalizeCharacterOutfits(outfits);
+    if (!normalized.length) return '';
+
+    return normalized
+        .map(outfit => {
+            const label = outfit.name || '服装';
+            return outfit.tags ? `${label}tag ${outfit.tags}` : label;
+        })
+        .join('; ');
+}
+
+function buildKnownCharacterBasePrompt(character = {}) {
+    const naiTag = character.danbooruTag ? danbooruToNai(character.danbooruTag) : '';
+    return joinTags(naiTag, character.type, character.appearance, buildCharacterOutfitReference(character.outfits));
+}
+
 function detectPresentCharacters(messageText, characterTags) {
     if (!messageText || !characterTags?.length) return [];
     const text = messageText.toLowerCase();
@@ -1044,6 +1071,7 @@ function detectPresentCharacters(messageText, characterTags) {
                 appearance: char.appearance || '',
                 danbooruTag: char.danbooruTag || '',
                 negativeTags: char.negativeTags || '',
+                outfits: normalizeCharacterOutfits(char.outfits),
             });
         }
     }
@@ -1059,10 +1087,9 @@ function assembleCharacterPrompts(sceneChars, knownCharacters) {
         );
 
         if (known) {
-            const naiTag = known.danbooruTag ? danbooruToNai(known.danbooruTag) : '';
             const defaultCenter = { x: 0.5, y: 0.5 };
             return {
-                prompt: joinTags(naiTag, known.type, known.appearance, char.costume, char.action, char.interact),
+                prompt: joinTags(buildKnownCharacterBasePrompt(known), char.costume, char.action, char.interact),
                 uc: joinTags(known.negativeTags, char.uc),
                 center: gridToCoord(char.center) || defaultCenter
             };
@@ -1147,6 +1174,7 @@ function autoLearnFromTasks(tasks, settings) {
                 appearance: char.appear || '',
                 negativeTags: '',
                 danbooruTag: char.danbooru || '',
+                outfits: [],
             };
             // 本地 DB 自动匹配 danbooruTag
             if (isDanbooruDBLoaded() && !newChar.danbooruTag) {
@@ -2057,7 +2085,7 @@ async function refreshSingleImage(container) {
             const message = ctx.chat?.[messageId];
             const presentCharacters = detectPresentCharacters(String(message?.mes || ''), settings.characterTags || []);
             characterPrompts = presentCharacters.map(c => ({
-                prompt: joinTags(c.type, c.appearance),
+                prompt: buildKnownCharacterBasePrompt(c),
                 uc: c.negativeTags || '',
                 center: { x: 0.5, y: 0.5 }
             }));
@@ -2209,7 +2237,7 @@ async function retryFailedImage(container) {
             const message = ctx.chat?.[messageId];
             const presentCharacters = detectPresentCharacters(String(message?.mes || ''), settings.characterTags || []);
             characterPrompts = presentCharacters.map(c => ({
-                prompt: joinTags(c.type, c.appearance),
+                prompt: buildKnownCharacterBasePrompt(c),
                 uc: c.negativeTags || '',
                 center: { x: 0.5, y: 0.5 }
             }));


### PR DESCRIPTION
1. 实现轻量化 DOM 局部更新
   - 弃用生成过程中的“全量重渲染”策略。
   - 优先通过 DOM Patch 直接替换文本节点中的占位符，或根据句子锚点精准插入图片节点。
   - 实现了多图批量处理，在滚动加载或初始化时，一次性处理多个占位符，大幅减少布局抖动。

2. 新增楼层级元数据持久化
   - 图片保存后，自动将 `savedUrl`、`tags`、`imgId` 和 `anchor` 写入消息对象的 `extra.novelDrawSaved` 字段。
   - 调整渲染优先级：**消息元数据 > 本地缓存 > 失败占位符**，确保已保存图片脱离 IndexedDB 也能正常显示。

3. 存储瘦身与清理策略逻辑优化
   - 图片保存成功并获得 `savedUrl` 后，自动清空本地缓存中的 `base64` 数据，仅保留轻量索引。
   - 增强清理函数：升级了“清理过期缓存”功能。现在除了清理过期记录外，还会自动对历史上已保存但仍残留 `base64` 的老记录进行批量“瘦身”，释放磁盘空间。

4. 渲染一致性保障
   - 优化了生成结束后的同步逻辑，仅在局部插入失败或必须强制刷新时才触发 full rerender。
   
5. 角色标签新增服装列表与搜索栏,优化相关布局