### PR TITLE
feat(novel-draw): 支持多楼层并发发起绘图，并为图片请求增加自动排队机制

### DIFF
--- a/modules/novel-draw/floating-panel.js
+++ b/modules/novel-draw/floating-panel.js
@@ -10,7 +10,6 @@ import {
     saveSettings,
     findLastAIMessageId,
     classifyError,
-    isGenerating,
 } from './novel-draw.js';
 import { registerToToolbar, removeFromToolbar } from '../../widgets/message-toolbar.js';
 
@@ -23,6 +22,7 @@ const AUTO_RESET_DELAY = 8000;
 
 const FloatState = {
     IDLE: 'idle',
+    QUEUED: 'queued',
     LLM: 'llm',
     GEN: 'gen',
     COOLDOWN: 'cooldown',
@@ -654,6 +654,13 @@ function setFloorState(messageId, state, data = {}) {
         case FloatState.IDLE:
             panelData.result = { success: 0, total: 0, error: null, startTime: 0 };
             break;
+        case FloatState.QUEUED:
+            el.classList.add('working');
+            if (!panelData.result.startTime) panelData.result.startTime = Date.now();
+            if (statusIcon) { statusIcon.textContent = '⌛'; statusIcon.className = 'nd-status-icon'; }
+            if (statusText) statusText.textContent = data.ahead > 0 ? `排队${data.ahead}` : '排队';
+            panelData.result.total = data.total || panelData.result.total || 0;
+            break;
         case FloatState.LLM:
             el.classList.add('working');
             panelData.result.startTime = Date.now();
@@ -755,16 +762,12 @@ async function handleFloorDrawClick(messageId) {
     const panelData = panelMap.get(messageId);
     if (!panelData || panelData.state !== FloatState.IDLE) return;
 
-    if (isGenerating()) {
-        toastr?.info?.('已有任务进行中，请等待完成');
-        return;
-    }
-
     try {
         await generateAndInsertImages({
             messageId,
             onStateChange: (state, data) => {
                 switch (state) {
+                    case 'queued': setFloorState(messageId, FloatState.QUEUED, data); break;
                     case 'llm': setFloorState(messageId, FloatState.LLM); break;
                     case 'gen': setFloorState(messageId, FloatState.GEN, data); break;
                     case 'progress': setFloorState(messageId, FloatState.GEN, data); break;
@@ -783,9 +786,9 @@ async function handleFloorDrawClick(messageId) {
         });
     } catch (e) {
         console.error('[NovelDraw]', e);
-        if (e.message === '已取消' || e.message?.includes('已有任务进行中')) {
+        if (e.message === '已取消' || e.message?.includes('已有任务进行中') || e.message?.includes('该楼层已有任务进行中')) {
             setFloorState(messageId, FloatState.IDLE);
-            if (e.message?.includes('已有任务进行中')) toastr?.info?.(e.message);
+            if (e.message?.includes('任务进行中')) toastr?.info?.(e.message);
         } else {
             setFloorState(messageId, FloatState.ERROR, { error: classifyError(e) });
         }
@@ -795,7 +798,7 @@ async function handleFloorDrawClick(messageId) {
 async function handleFloorAbort(messageId) {
     try {
         const { abortGeneration } = await import('./novel-draw.js');
-        if (abortGeneration()) {
+        if (abortGeneration(messageId)) {
             setFloorState(messageId, FloatState.IDLE);
             toastr?.info?.('已中止');
         }
@@ -825,7 +828,7 @@ function bindFloorPanelEvents(panelData) {
     el.querySelector('.nd-layer-active')?.addEventListener('click', (e) => {
         e.stopPropagation();
         const state = panelData.state;
-        if ([FloatState.LLM, FloatState.GEN, FloatState.COOLDOWN].includes(state)) {
+        if ([FloatState.QUEUED, FloatState.LLM, FloatState.GEN, FloatState.COOLDOWN].includes(state)) {
             handleFloorAbort(messageId);
         } else if ([FloatState.SUCCESS, FloatState.PARTIAL, FloatState.ERROR].includes(state)) {
             updateFloorDetailPopup(messageId);
@@ -1082,6 +1085,13 @@ function setFloatingState(state, data = {}) {
         case FloatState.IDLE:
             floatingResult = { success: 0, total: 0, error: null, startTime: 0 };
             break;
+        case FloatState.QUEUED:
+            floatingEl.classList.add('working');
+            if (!floatingResult.startTime) floatingResult.startTime = Date.now();
+            statusIcon.textContent = '⌛';
+            statusIcon.className = 'nd-status-icon';
+            statusText.textContent = data.ahead > 0 ? `排队${data.ahead}` : '排队';
+            break;
         case FloatState.LLM:
             floatingEl.classList.add('working');
             floatingResult.startTime = Date.now();
@@ -1219,7 +1229,7 @@ function routeFloatingClick(target) {
         }
         floatingEl.classList.toggle('expanded');
     } else if (target.closest('.nd-layer-active')) {
-        if ([FloatState.LLM, FloatState.GEN, FloatState.COOLDOWN].includes(floatingState)) {
+        if ([FloatState.QUEUED, FloatState.LLM, FloatState.GEN, FloatState.COOLDOWN].includes(floatingState)) {
             handleFloatingAbort();
         } else if ([FloatState.SUCCESS, FloatState.PARTIAL, FloatState.ERROR].includes(floatingState)) {
             updateFloatingDetailPopup();
@@ -1237,16 +1247,12 @@ async function handleFloatingDrawClick() {
         return;
     }
 
-    if (isGenerating()) {
-        toastr?.info?.('已有任务进行中，请等待完成');
-        return;
-    }
-
     try {
         await generateAndInsertImages({
             messageId,
             onStateChange: (state, data) => {
                 switch (state) {
+                    case 'queued': setFloatingState(FloatState.QUEUED, data); break;
                     case 'llm': setFloatingState(FloatState.LLM); break;
                     case 'gen': setFloatingState(FloatState.GEN, data); break;
                     case 'progress': setFloatingState(FloatState.GEN, data); break;
@@ -1265,9 +1271,9 @@ async function handleFloatingDrawClick() {
         });
     } catch (e) {
         console.error('[NovelDraw]', e);
-        if (e.message === '已取消' || e.message?.includes('已有任务进行中')) {
+        if (e.message === '已取消' || e.message?.includes('已有任务进行中') || e.message?.includes('该楼层已有任务进行中')) {
             setFloatingState(FloatState.IDLE);
-            if (e.message?.includes('已有任务进行中')) toastr?.info?.(e.message);
+            if (e.message?.includes('任务进行中')) toastr?.info?.(e.message);
         } else {
             setFloatingState(FloatState.ERROR, { error: classifyError(e) });
         }
@@ -1277,7 +1283,8 @@ async function handleFloatingDrawClick() {
 async function handleFloatingAbort() {
     try {
         const { abortGeneration } = await import('./novel-draw.js');
-        if (abortGeneration()) {
+        const messageId = findLastAIMessageId();
+        if (messageId >= 0 && abortGeneration(messageId)) {
             setFloatingState(FloatState.IDLE);
             toastr?.info?.('已中止');
         }

--- a/modules/novel-draw/novel-draw.js
+++ b/modules/novel-draw/novel-draw.js
@@ -173,7 +173,10 @@ let moduleInitialized = false;
 let touchState = null;
 let settingsCache = null;
 let settingsLoaded = false;
-let generationAbortController = null;
+let generationJobs = new Map();
+let imageRequestQueue = [];
+let activeImageRequest = null;
+let imageRequestSeq = 0;
 let messageObserver = null;
 let ensureNovelDrawPanelRef = null;
 let overlayResizeHandler = null;
@@ -642,18 +645,108 @@ function insertPreviewIntoRenderedMessage({ messageId, slotId, html, anchor = ''
 // 中止控制
 // ═══════════════════════════════════════════════════════════════════════════
 
-function abortGeneration() {
-    if (generationAbortController) {
-        generationAbortController.abort();
-        // controller 由 generateAndInsertImages 的 finally 块清除
-        // autoBusy 由 autoGenerateForLastAI 的 finally 块清除
+function abortGeneration(messageId = null) {
+    if (messageId !== null && messageId !== undefined) {
+        const job = generationJobs.get(String(messageId));
+        if (!job) return false;
+        job.controller.abort();
         return true;
     }
-    return false;
+
+    let aborted = false;
+    generationJobs.forEach((job) => {
+        job.controller.abort();
+        aborted = true;
+    });
+    return aborted;
 }
 
 function isGenerating() {
-    return autoBusy || generationAbortController !== null;
+    return autoBusy || generationJobs.size > 0;
+}
+
+function hasGenerationJob(messageId) {
+    return generationJobs.has(String(messageId));
+}
+
+function createGenerationJob(messageId) {
+    const key = String(messageId);
+    if (generationJobs.has(key)) {
+        throw new NovelDrawError('该楼层已有任务进行中', ErrorType.UNKNOWN);
+    }
+
+    const job = {
+        key,
+        messageId,
+        controller: new AbortController(),
+        createdAt: Date.now(),
+    };
+    generationJobs.set(key, job);
+    return job;
+}
+
+function releaseGenerationJob(job) {
+    if (job && generationJobs.get(job.key) === job) {
+        generationJobs.delete(job.key);
+    }
+}
+
+function notifyQueuedImageRequests() {
+    imageRequestQueue.forEach((item, index) => {
+        const ahead = (activeImageRequest ? 1 : 0) + index;
+        if (ahead > 0) {
+            item.onQueued?.({ ahead, position: ahead + 1 });
+        }
+    });
+}
+
+function pumpImageRequestQueue() {
+    if (activeImageRequest || imageRequestQueue.length === 0) return;
+
+    const item = imageRequestQueue.shift();
+    activeImageRequest = item;
+    notifyQueuedImageRequests();
+
+    Promise.resolve()
+        .then(async () => {
+            if (item.signal?.aborted) throw new NovelDrawError('已取消', ErrorType.UNKNOWN);
+            item.onStart?.();
+            return await item.run();
+        })
+        .then(item.resolve)
+        .catch(item.reject)
+        .finally(() => {
+            if (activeImageRequest === item) {
+                activeImageRequest = null;
+            }
+            notifyQueuedImageRequests();
+            pumpImageRequestQueue();
+        });
+}
+
+function enqueueImageRequest(run, { signal, onQueued, onStart } = {}) {
+    return new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+            reject(new NovelDrawError('已取消', ErrorType.UNKNOWN));
+            return;
+        }
+
+        const item = { id: ++imageRequestSeq, run, signal, onQueued, onStart, resolve, reject };
+
+        signal?.addEventListener('abort', () => {
+            if (activeImageRequest === item) return;
+            const idx = imageRequestQueue.indexOf(item);
+            if (idx >= 0) {
+                imageRequestQueue.splice(idx, 1);
+                notifyQueuedImageRequests();
+                reject(new NovelDrawError('已取消', ErrorType.UNKNOWN));
+            }
+        }, { once: true });
+
+        imageRequestQueue.push(item);
+        notifyQueuedImageRequests();
+        pumpImageRequestQueue();
+    });
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1330,56 +1423,62 @@ function buildNovelAIRequestBody({ scene, characterPrompts, negativePrompt, para
     };
 }
 
-async function generateNovelImage({ scene, characterPrompts, negativePrompt, params, signal }) {
-    const settings = getSettings();
-    if (!settings.apiKey) throw new NovelDrawError('请先配置 API Key', ErrorType.AUTH);
+async function generateNovelImage({ scene, characterPrompts, negativePrompt, params, signal, onQueueStateChange }) {
+    return await enqueueImageRequest(async () => {
+        const settings = getSettings();
+        if (!settings.apiKey) throw new NovelDrawError('请先配置 API Key', ErrorType.AUTH);
 
-    const finalParams = { ...params };
+        const finalParams = { ...params };
 
-    if (settings.overrideSize && settings.overrideSize !== 'default') {
-        const { SIZE_OPTIONS } = await import('./floating-panel.js');
-        const sizeOpt = SIZE_OPTIONS.find(o => o.value === settings.overrideSize);
-        if (sizeOpt && sizeOpt.width && sizeOpt.height) {
-            finalParams.width = sizeOpt.width;
-            finalParams.height = sizeOpt.height;
+        if (settings.overrideSize && settings.overrideSize !== 'default') {
+            const { SIZE_OPTIONS } = await import('./floating-panel.js');
+            const sizeOpt = SIZE_OPTIONS.find(o => o.value === settings.overrideSize);
+            if (sizeOpt && sizeOpt.width && sizeOpt.height) {
+                finalParams.width = sizeOpt.width;
+                finalParams.height = sizeOpt.height;
+            }
         }
-    }
 
-    const controller = new AbortController();
-    const timeout = (settings.timeout > 0) ? settings.timeout : DEFAULT_SETTINGS.timeout;
-    const tid = setTimeout(() => controller.abort(), timeout);
+        const controller = new AbortController();
+        const timeout = (settings.timeout > 0) ? settings.timeout : DEFAULT_SETTINGS.timeout;
+        const tid = setTimeout(() => controller.abort(), timeout);
 
-    if (signal) {
-        signal.addEventListener('abort', () => controller.abort(), { once: true });
-    }
+        if (signal) {
+            signal.addEventListener('abort', () => controller.abort(), { once: true });
+        }
 
-    const t0 = Date.now();
+        const t0 = Date.now();
 
-    try {
-        if (signal?.aborted) throw new NovelDrawError('已取消', ErrorType.UNKNOWN);
+        try {
+            if (signal?.aborted) throw new NovelDrawError('已取消', ErrorType.UNKNOWN);
 
-        const res = await fetch(NOVELAI_IMAGE_API, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${settings.apiKey}` },
-            signal: controller.signal,
-            body: JSON.stringify(buildNovelAIRequestBody({
-                scene,
-                characterPrompts,
-                negativePrompt,
-                params: finalParams
-            })),
-        });
-        if (!res.ok) throw parseApiError(res.status, await res.text().catch(() => ''));
-        const buffer = await res.arrayBuffer();
-        const base64 = await extractImageFromZip(buffer);
-        console.log(`[NovelDraw] 完成 ${Date.now() - t0}ms`);
-        return base64;
-    } catch (e) {
-        if (signal?.aborted) throw new NovelDrawError('已取消', ErrorType.UNKNOWN);
-        throw handleFetchError(e);
-    } finally {
-        clearTimeout(tid);
-    }
+            const res = await fetch(NOVELAI_IMAGE_API, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${settings.apiKey}` },
+                signal: controller.signal,
+                body: JSON.stringify(buildNovelAIRequestBody({
+                    scene,
+                    characterPrompts,
+                    negativePrompt,
+                    params: finalParams
+                })),
+            });
+            if (!res.ok) throw parseApiError(res.status, await res.text().catch(() => ''));
+            const buffer = await res.arrayBuffer();
+            const base64 = await extractImageFromZip(buffer);
+            console.log(`[NovelDraw] 完成 ${Date.now() - t0}ms`);
+            return base64;
+        } catch (e) {
+            if (signal?.aborted) throw new NovelDrawError('已取消', ErrorType.UNKNOWN);
+            throw handleFetchError(e);
+        } finally {
+            clearTimeout(tid);
+        }
+    }, {
+        signal,
+        onQueued: (data) => onQueueStateChange?.('queued', data),
+        onStart: () => onQueueStateChange?.('start'),
+    });
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -2500,19 +2599,19 @@ async function handleMessageModified(data) {
 // ═══════════════════════════════════════════════════════════════════════════
 
 async function generateAndInsertImages({ messageId, onStateChange, skipLock = false }) {
-    await loadSettings();
-    const ctx = getContext();
-    const message = ctx.chat?.[messageId];
-    if (!message) throw new NovelDrawError('消息不存在', ErrorType.PARSE);
-
-    if (!skipLock && isGenerating()) {
-        throw new NovelDrawError('已有任务进行中', ErrorType.UNKNOWN);
+    if (skipLock) {
+        // 兼容旧调用：当前改为 message 级去重 + 图片请求队列，不再使用全局生成锁
     }
 
-    generationAbortController = new AbortController();
-    const signal = generationAbortController.signal;
+    const job = createGenerationJob(messageId);
 
     try {
+        await loadSettings();
+        const ctx = getContext();
+        const message = ctx.chat?.[messageId];
+        if (!message) throw new NovelDrawError('消息不存在', ErrorType.PARSE);
+
+        const signal = job.controller.signal;
         const settings = getSettings();
         const preset = getActiveParamsPreset();
 
@@ -2668,7 +2767,15 @@ async function generateAndInsertImages({ messageId, onStateChange, skipLock = fa
                     characterPrompts,
                     negativePrompt: preset.negativePrefix || '',
                     params: preset.params || {},
-                    signal
+                    signal,
+                    onQueueStateChange: (queueState, queueData) => {
+                        if (queueState === 'queued') {
+                            onStateChange?.('queued', { current: i + 1, total: tasks.length, ...queueData });
+                        }
+                        if (queueState === 'start') {
+                            onStateChange?.('progress', { current: i + 1, total: tasks.length });
+                        }
+                    }
                 });
                 const imgId = generateImgId();
                 await storePreview({
@@ -2852,7 +2959,7 @@ async function generateAndInsertImages({ messageId, onStateChange, skipLock = fa
         return { success: successCount, total: tasks.length, results };
 
     } finally {
-        generationAbortController = null;
+        releaseGenerationJob(job);
     }
 }
 
@@ -2864,11 +2971,6 @@ async function autoGenerateForLastAI() {
     const s = getSettings();
     if (!isModuleEnabled() || s.mode !== 'auto') return;
 
-    if (isGenerating()) {
-        console.log('[NovelDraw] 自动模式：已有任务进行中，跳过');
-        return;
-    }
-    
     const ctx = getContext();
     const chat = ctx.chat || [];
     const lastIdx = chat.length - 1;
@@ -2882,6 +2984,11 @@ async function autoGenerateForLastAI() {
     
     lastMessage.extra ||= {};
     if (lastMessage.extra.xb_novel_auto_done) return;
+
+    if (autoBusy || hasGenerationJob(lastIdx)) {
+        console.log('[NovelDraw] 自动模式：当前楼层已有任务进行中，跳过');
+        return;
+    }
     
     autoBusy = true;
     
@@ -2911,6 +3018,9 @@ async function autoGenerateForLastAI() {
             skipLock: true,
             onStateChange: (state, data) => {
                 switch (state) {
+                    case 'queued':
+                        updateState(FloatState.QUEUED, data);
+                        break;
                     case 'llm': 
                         updateState(FloatState.LLM); 
                         break;
@@ -3648,6 +3758,7 @@ async function handleFrameMessage(event) {
                     messageId,
                     onStateChange: (state, d) => {
                         if (state === 'progress') postStatus('loading', `${d.current}/${d.total}`);
+                        if (state === 'queued') postStatus('loading', d.ahead > 0 ? `排队中·前方 ${d.ahead}` : '排队中');
                     }
                 });
                 postStatus('success', `完成! ${result.success} 张`);
@@ -3827,6 +3938,11 @@ export async function cleanupNovelDraw() {
     destroyCloudPresets();
     overlayCreated = false;
     frameReady = false;
+
+    abortGeneration();
+    generationJobs.clear();
+    imageRequestQueue = [];
+    activeImageRequest = null;
 
     if (messageObserver) {
         messageObserver.disconnect();


### PR DESCRIPTION
 对 `LittleWhiteBox/modules/novel-draw` 的绘图流程进行了优化，实现了：

1. **不同楼层可同时发起绘图任务**
   - 取消原有的全局单任务限制
   - 改为按 `messageId` / 楼层维度管理绘图任务
   - 同一楼层仍会防止重复提交，但不同楼层之间互不阻塞

2. **图片生成请求统一自动排队**
   - 新增全局图片请求队列
   - 所有真正的出图请求都会进入统一队列串行执行
   - 避免多楼层、多图片、自动模式和手动模式并发时的请求冲突

3. **支持排队状态反馈**
   - 为楼层按钮 / 悬浮按钮新增 `QUEUED` 状态
   - 当任务已创建但前方仍有图片请求时，可显示排队状态
   - 排队中的任务也支持取消

4. **中止逻辑细化为按楼层中止**
   - 楼层面板中止仅影响当前楼层任务
   - 悬浮按钮中止仅影响当前对应消息任务
   - 保留全局停止事件下的统一中止能力

5. **同一楼层内的重新生成也会进入队列**
   - 单图刷新（refresh）
   - 失败图重试（retry）
   - 多图批量生成中的单张出图  
   以上都会复用统一的图片请求队列

---

## 行为变化

### 之前
- 任意一个楼层开始绘图后，其他楼层无法发起绘图
- 出图请求之间缺少统一排队层

### 现在
- 多个楼层可以同时开始绘图流程
- 图片生成请求会自动顺序排队
- 同楼层不同图片的重新生成 / 重试也会复用同一套排队机制
- 同一楼层的重复提交仍会被拦截，避免重复任务

---

## 影响范围
- `LittleWhiteBox/modules/novel-draw/novel-draw.js`
- `LittleWhiteBox/modules/novel-draw/floating-panel.js`