### PR TITLE
修复自定义工作流中非标准文本字段名导致验证失败的问题

### DIFF
--- a/modules/draw/providers/comfyui/comfy-draw.js
+++ b/modules/draw/providers/comfyui/comfy-draw.js
@@ -1180,14 +1180,24 @@ function resolveComfyDirectOutputImage(item, workflow, preferredSaveImageNodeId 
     return saveImageAsset || null;
 }
 
+function injectTextFieldIntoNode(nodeInputs, value) {
+    for (const key of ['text', 'positive', 'negative', 'prompt']) {
+        if (key in nodeInputs && typeof nodeInputs[key] === 'string') {
+            nodeInputs[key] = value;
+            return;
+        }
+    }
+    nodeInputs.text = value;
+}
+
 function injectPromptIntoWorkflow(workflow, positive, negative, width, height, nodeMap) {
     const wf = JSON.parse(JSON.stringify(workflow));
     validateComfyWorkflowNodeMap(wf, nodeMap);
     if (nodeMap.positive && wf[nodeMap.positive]) {
-        wf[nodeMap.positive].inputs.text = positive;
+        injectTextFieldIntoNode(wf[nodeMap.positive].inputs, positive);
     }
     if (nodeMap.negative && wf[nodeMap.negative]) {
-        wf[nodeMap.negative].inputs.text = negative;
+        injectTextFieldIntoNode(wf[nodeMap.negative].inputs, negative);
     }
     if (nodeMap.width && width && wf[nodeMap.width]) {
         const widthNode = wf[nodeMap.width].inputs;

--- a/modules/draw/providers/comfyui/comfy-draw.js
+++ b/modules/draw/providers/comfyui/comfy-draw.js
@@ -1038,8 +1038,9 @@ function validateComfyTextNode(workflow, nodeId, label, { required = false } = {
         return;
     }
     const node = requireComfyNode(workflow, id, label);
-    if (!('text' in node.inputs)) {
-        throw new Error(`${label}需要填 CLIP Text Encode 这类带 text 输入的节点：${id}`);
+    const hasTextField = ['text', 'positive', 'negative', 'prompt'].some(k => k in node.inputs);
+    if (!hasTextField) {
+        throw new Error(`${label}需要填带 text/positive/prompt 输入的节点：${id}`);
     }
 }
 


### PR DESCRIPTION
## 功能概要

修复在使用自定义工作流时，如果提示词节点的文本字段名称不是标准的 `text`（例如 WeiLin 系列节点使用 `positive`/`negative`，或其他节点使用 `prompt`），会导致验证阶段直接报错、无法注入提示词的问题。

## 变更范围

`modules/draw/providers/comfyui/comfy-draw.js`

**Commit 1 — 注入层兼容（injectTextFieldIntoNode）**
- 新增 `injectTextFieldIntoNode` 辅助函数，按优先级探测 `text` → `positive` → `negative` → `prompt` 字段名
- `injectPromptIntoWorkflow` 改为调用该函数，替代原先硬编码的 `.text =` 赋值

**Commit 2 — 验证层对齐**
- `validateComfyTextNode` 原先只检查 `'text' in node.inputs`，现在与注入层一致，接受 `text`、`positive`、`negative`、`prompt` 四种字段名
- 错误提示同步更新

## 测试要点

- [ ] 使用标准 CLIP Text Encode 节点（字段名 `text`）的工作流正常验证和注入
- [ ] 使用 WeiLin 系列节点（字段名 `positive`/`negative`）的工作流正常验证和注入
- [ ] 使用其他自定义节点（字段名 `prompt`）的工作流正常验证和注入
- [ ] 节点不含任何已知文本字段时，仍然正确报错提示