### PR TITLE
NovelAI 绘图支持第三方端点与后端发送模式

### DIFF
--- a/modules/draw/providers/novelai/novel-draw.html
+++ b/modules/draw/providers/novelai/novel-draw.html
@@ -154,6 +154,18 @@ select.input { cursor: pointer; }
 .btn-danger:hover { background: rgba(248, 81, 73, 0.1); }
 .btn-icon { width: 40px; padding: 0; }
 .btn-group { display: flex; gap: 8px; flex-wrap: wrap; }
+.nd-mode-btn.mode-active { background: var(--accent); border-color: var(--accent); color: #000; font-weight: 500; }
+.nd-mode-btn.mode-active:hover { background: #e5b685; }
+.nd-backend-panel { margin-top: 12px; padding: 10px 12px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-tertiary); }
+.nd-backend-status-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.nd-status-dot { width: 10px; height: 10px; border-radius: 50%; background: #888; flex: 0 0 auto; }
+.nd-status-dot.ok { background: #3ecf8e; box-shadow: 0 0 6px rgba(62,207,142,0.6); }
+.nd-status-dot.bad { background: #f85149; box-shadow: 0 0 6px rgba(248,81,73,0.6); }
+.nd-status-dot.checking { background: #f0b429; }
+.nd-status-txt { font-size: 13px; color: var(--text-primary); flex: 1 1 auto; }
+.nd-backend-status-row .btn-sm { margin-left: auto; }
+.nd-guide-steps { margin: 6px 0 0; padding-left: 20px; font-size: 12px; color: var(--text-secondary, #aaa); line-height: 1.7; }
+.nd-guide-steps code { background: rgba(255,255,255,0.08); padding: 1px 5px; border-radius: 4px; font-size: 11px; }
 .btn-sm { padding: 6px 10px; min-height: 32px; font-size: 12px; }
 .btn.saving { pointer-events: none; opacity: 0.7; }
 .btn.save-success { background: var(--success) !important; border-color: var(--success) !important; color: #fff !important; pointer-events: none; }
@@ -701,6 +713,41 @@ select.input { cursor: pointer; }
                             <button id="nd_toggle_key" class="btn btn-icon"><i class="fa-solid fa-eye"></i></button>
                         </div>
                         <p class="form-hint">仅存储在本地浏览器</p>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">第三方端点 URL（可选）</label>
+                        <div class="input-row">
+                            <input id="nd_api_base_url" type="text" class="input" placeholder="https://image.novelai.net">
+                            <button id="nd_reset_base_url" class="btn btn-icon" title="重置为官方地址"><i class="fa-solid fa-rotate-left"></i></button>
+                        </div>
+                        <p class="form-hint">留空使用官方端点。填写中转/反代地址时只需填根地址（如 https://xxx.com），会自动追加 /ai/generate-image；点重置按钮可恢复为官方地址。</p>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">发送方式</label>
+                        <div class="btn-group" id="nd_send_mode_group">
+                            <button type="button" class="btn nd-mode-btn" data-send-mode="frontend"><i class="fa-solid fa-globe"></i> 前端直连</button>
+                            <button type="button" class="btn nd-mode-btn" data-send-mode="backend"><i class="fa-solid fa-server"></i> 后端发送</button>
+                        </div>
+                        <label class="check-row" style="margin-top:8px;"><input type="checkbox" id="nd_insecure_tls"> 忽略证书验证（仅后端发送模式、连接自签证书端点时勾选）</label>
+                        <p class="form-hint">前端直连：浏览器直接请求（需对方支持 CORS + 有效证书）。后端发送：由酒馆后端代发，可绕过 CORS 与自签证书。</p>
+
+                        <!-- 后端插件状态栏（仅后端发送模式显示） -->
+                        <div id="nd_backend_panel" class="nd-backend-panel hidden">
+                            <div class="nd-backend-status-row">
+                                <span id="nd_backend_dot" class="nd-status-dot"></span>
+                                <span id="nd_backend_status_text" class="nd-status-txt">检测中...</span>
+                                <button id="nd_backend_recheck" class="btn btn-sm" type="button"><i class="fa-solid fa-rotate"></i> 重新检测</button>
+                            </div>
+                            <div id="nd_backend_guide" class="nd-backend-guide hidden">
+                                <p class="form-hint" style="margin-top:4px;">后端插件未就绪。插件文件已随 LittleWhiteBox 一起下载，只需手动搬到酒馆的后端插件目录并重启：</p>
+                                <ol class="nd-guide-steps">
+                                    <li>找到插件文件夹（在本扩展目录下）：<br><code>SillyTavern/public/scripts/extensions/third-party/LittleWhiteBox/server-plugin/littlewhitebox-nai/</code></li>
+                                    <li>把整个 <code>littlewhitebox-nai</code> 文件夹（含 <code>index.js</code> / <code>package.json</code> / <code>manifest.json</code>）剪切或复制到：<br><code>SillyTavern/plugins/littlewhitebox-nai/</code></li>
+                                    <li>用文本编辑器打开 <code>SillyTavern/config.yaml</code>，找到 <code>enableServerPlugins</code> 一行改为 <code>enableServerPlugins: true</code>（若没有这一行就新增）</li>
+                                    <li>完全关闭并重启 SillyTavern，回到这里点“重新检测”</li>
+                                </ol>
+                            </div>
+                        </div>
                     </div>
                     <div class="form-row">
                         <div class="form-group">
@@ -1375,6 +1422,9 @@ let state = {
     enabled: false,
     mode: 'manual',
     apiKey: '',
+    apiBaseUrl: '',
+    sendMode: 'frontend',
+    insecureTLS: false,
     timeout: DEFAULTS.timeout,
     requestDelay: { ...DEFAULTS.requestDelay },
     cacheDays: DEFAULTS.cacheDays,
@@ -1505,6 +1555,41 @@ function switchView(viewId) {
 
 function updateModeButtons(mode) {
     $$('.header-mode button').forEach(btn => btn.classList.toggle('active', btn.dataset.mode === mode));
+}
+
+function updateSendModeUI(mode) {
+    const m = mode === 'backend' ? 'backend' : 'frontend';
+    const group = $('nd_send_mode_group');
+    if (group) {
+        group.querySelectorAll('.nd-mode-btn').forEach(btn => {
+            btn.classList.toggle('mode-active', btn.dataset.sendMode === m);
+        });
+    }
+    state.sendMode = m;
+    const panel = $('nd_backend_panel');
+    if (panel) {
+        panel.classList.toggle('hidden', m !== 'backend');
+        if (m === 'backend') requestBackendPluginCheck();
+    }
+}
+
+function requestBackendPluginCheck() {
+    setBackendStatusUI('checking', '检测中...');
+    postToParent({ type: 'CHECK_BACKEND_PLUGIN' });
+}
+
+function setBackendStatusUI(state, text) {
+    const dot = $('nd_backend_dot');
+    const txt = $('nd_backend_status_text');
+    const guide = $('nd_backend_guide');
+    if (dot) dot.className = 'nd-status-dot ' + (state === 'ok' ? 'ok' : state === 'bad' ? 'bad' : 'checking');
+    if (txt) txt.textContent = text || '';
+    if (guide) guide.classList.toggle('hidden', state !== 'bad');
+}
+
+function getSendMode() {
+    const active = $('nd_send_mode_group')?.querySelector('.nd-mode-btn.mode-active');
+    return active?.dataset?.sendMode === 'backend' ? 'backend' : 'frontend';
 }
 
 function updateBadge(enabled) {
@@ -2411,6 +2496,9 @@ function applyStateToUI() {
         $('nd_show_floating').checked = state.showFloatingButton === true;
 
         $('nd_api_key').value = state.apiKey || '';
+        $('nd_api_base_url').value = state.apiBaseUrl || '';
+        updateSendModeUI(state.sendMode === 'backend' ? 'backend' : 'frontend');
+        $('nd_insecure_tls').checked = state.insecureTLS === true;
         $('nd_timeout').value = Math.round((state.timeout > 0 ? state.timeout : DEFAULTS.timeout) / 1000);
         const dMin = state.requestDelay?.min > 0 ? state.requestDelay.min : DEFAULTS.requestDelay.min;
         const dMax = state.requestDelay?.max > 0 ? state.requestDelay.max : DEFAULTS.requestDelay.max;
@@ -2611,6 +2699,22 @@ window.addEventListener('message', event => {
             $('nd_preview_img').src = data.url;
             $('nd_preview').classList.add('visible');
             break;
+
+        case 'BACKEND_PLUGIN_STATUS': {
+            const st = data.status || {};
+            if (st.ready) {
+                setBackendStatusUI('ok', `后端插件已就绪${st.version ? '（v' + st.version + '）' : ''}`);
+            } else {
+                const reasonText = st.reason === 'unreachable'
+                    ? '无法连接后端（可能未开启 enableServerPlugins）'
+                    : st.reason === 'not_installed'
+                        ? '后端插件未安装'
+                        : '后端插件未就绪';
+                setBackendStatusUI('bad', reasonText);
+            }
+            break;
+        }
+
             
         case 'STATUS':
             if (data.target === 'worldbook') {
@@ -2780,17 +2884,64 @@ document.addEventListener('DOMContentLoaded', () => {
         else { i.type = 'password'; ic.className = 'fa-solid fa-eye'; }
     });
     
+    $('nd_reset_base_url').addEventListener('click', () => {
+        $('nd_api_base_url').value = '';
+        setSavingState($('nd_save_api'));
+        postToParent({
+            type: 'SAVE_API_CONFIG',
+            apiKey: $('nd_api_key').value.trim(),
+            apiBaseUrl: '',
+            sendMode: getSendMode(),
+            insecureTLS: $('nd_insecure_tls').checked,
+            timeout: Number($('nd_timeout').value) * 1000 || 180000,
+            requestDelay: parseDelay($('nd_delay').value)
+        });
+    });
+
+    $('nd_send_mode_group').querySelectorAll('.nd-mode-btn').forEach((btn) => {
+        btn.addEventListener('click', () => {
+            const mode = btn.dataset.sendMode === 'backend' ? 'backend' : 'frontend';
+            updateSendModeUI(mode);
+            postToParent({
+                type: 'SAVE_API_CONFIG',
+                apiKey: $('nd_api_key').value.trim(),
+                apiBaseUrl: $('nd_api_base_url').value.trim(),
+                sendMode: mode,
+                insecureTLS: $('nd_insecure_tls').checked,
+                timeout: Number($('nd_timeout').value) * 1000 || 180000,
+                requestDelay: parseDelay($('nd_delay').value)
+            });
+        });
+    });
+
+    $('nd_insecure_tls').addEventListener('change', () => {
+        postToParent({
+            type: 'SAVE_API_CONFIG',
+            apiKey: $('nd_api_key').value.trim(),
+            apiBaseUrl: $('nd_api_base_url').value.trim(),
+            sendMode: getSendMode(),
+            insecureTLS: $('nd_insecure_tls').checked,
+            timeout: Number($('nd_timeout').value) * 1000 || 180000,
+            requestDelay: parseDelay($('nd_delay').value)
+        });
+    });
+
+    $('nd_backend_recheck').addEventListener('click', () => requestBackendPluginCheck());
+
     $('nd_save_api').addEventListener('click', () => {
         setSavingState($('nd_save_api'));
         postToParent({
             type: 'SAVE_API_CONFIG',
             apiKey: $('nd_api_key').value.trim(),
+            apiBaseUrl: $('nd_api_base_url').value.trim(),
+            sendMode: getSendMode(),
+            insecureTLS: $('nd_insecure_tls').checked,
             timeout: Number($('nd_timeout').value) * 1000 || 180000,
             requestDelay: parseDelay($('nd_delay').value)
         });
     });
     
-    $('nd_test_api').addEventListener('click', () => postToParent({ type: 'TEST_API', apiKey: $('nd_api_key').value.trim() }));
+    $('nd_test_api').addEventListener('click', () => postToParent({ type: 'TEST_API', apiKey: $('nd_api_key').value.trim(), apiBaseUrl: $('nd_api_base_url').value.trim(), sendMode: getSendMode(), insecureTLS: $('nd_insecure_tls').checked }));
     
     $('nd_test_single').addEventListener('click', () => postToParent({ type: 'TEST_SINGLE', tags: $('nd_test_tags').value }));
     

--- a/modules/draw/providers/novelai/novel-draw.js
+++ b/modules/draw/providers/novelai/novel-draw.js
@@ -6,6 +6,7 @@
 
 import { getContext } from "../../../../../../../extensions.js";
 import { saveBase64AsFile } from "../../../../../../../utils.js";
+import { getRequestHeaders } from "../../../../../../../../script.js";
 import { extensionFolderPath } from "../../../../core/constants.js";
 import { createModuleEvents, event_types } from "../../../../core/event-manager.js";
 import { NovelDrawStorage } from "../../../../core/server-storage.js";
@@ -66,8 +67,41 @@ import {
 const MODULE_KEY = 'novelDraw';
 const SERVER_FILE_KEY = 'settings';
 const HTML_PATH = `${extensionFolderPath}/modules/draw/providers/novelai/novel-draw.html`;
+const NOVELAI_DEFAULT_BASE_URL = 'https://image.novelai.net';
 const NOVELAI_IMAGE_API = 'https://image.novelai.net/ai/generate-image';
-const CONFIG_VERSION = 5;
+// 后端发送模式走 SillyTavern server plugin 转发（需安装 plugins/littlewhitebox-nai 并开启 enableServerPlugins），
+// 用于绕过浏览器 CORS / 自签证书限制。
+const NAI_BACKEND_GENERATE = '/api/plugins/littlewhitebox-nai/generate-image';
+const NAI_BACKEND_TEST = '/api/plugins/littlewhitebox-nai/test';
+const NAI_BACKEND_STATUS = '/api/plugins/littlewhitebox-nai/status';
+const CONFIG_VERSION = 7;
+
+// 探测后端 server plugin 是否已安装并就绪。返回 { ready, version?, reason }。
+async function checkBackendPluginStatus() {
+    try {
+        const res = await fetch(NAI_BACKEND_STATUS, { method: 'GET', headers: getRequestHeaders() });
+        if (res.status === 404) return { ready: false, reason: 'not_installed' };
+        if (!res.ok) return { ready: false, reason: `http_${res.status}` };
+        const data = await res.json().catch(() => null);
+        if (data && data.ok === true) return { ready: true, version: data.version || '' };
+        return { ready: false, reason: 'bad_response' };
+    } catch (e) {
+        return { ready: false, reason: 'unreachable' };
+    }
+}
+
+// 将用户填写的第三方 base_url 规范化为 NovelAI 生成图片端点。
+// 兼容三种写法：
+//   1) 官方/中转根地址（如 https://image.novelai.net 或 https://xxx.com） → 追加 /ai/generate-image
+//   2) 已含 /ai/generate-image 的完整端点 → 原样使用
+//   3) 空 → 回退官方端点
+function resolveNovelAIImageApi(baseUrl) {
+    const raw = String(baseUrl || '').trim();
+    if (!raw) return NOVELAI_IMAGE_API;
+    const trimmed = raw.replace(/\/+$/, '');
+    if (/\/ai\/generate-image$/i.test(trimmed)) return trimmed;
+    return `${trimmed}/ai/generate-image`;
+}
 const MAX_SEED = 0xFFFFFFFF;
 const API_TEST_TIMEOUT = 15000;
 const PLACEHOLDER_REGEX = /\[image:([a-z0-9\-_]+)\]/gi;
@@ -156,6 +190,9 @@ const DEFAULT_SETTINGS = {
     updatedAt: 0,
     mode: 'manual',
     apiKey: '',
+    apiBaseUrl: '',
+    sendMode: 'frontend',
+    insecureTLS: false,
     selectedParamsPresetId: null,
     paramsPresets: [],
     requestDelay: { min: 15000, max: 30000 },
@@ -770,6 +807,9 @@ function handleFetchError(e) {
 function normalizeSettings(saved) {
     const merged = { ...DEFAULT_SETTINGS, ...(saved || {}) };
     merged.advancedMode = true;
+    merged.apiBaseUrl = typeof merged.apiBaseUrl === 'string' ? merged.apiBaseUrl.trim() : '';
+    merged.sendMode = merged.sendMode === 'backend' ? 'backend' : 'frontend';
+    merged.insecureTLS = !!merged.insecureTLS;
     merged.llmApi = normalizeDrawLlmApi({ ...DEFAULT_SETTINGS.llmApi, ...(saved?.llmApi || {}) });
     merged.customPrompts = { ...DEFAULT_SETTINGS.customPrompts, ...(saved?.customPrompts || {}) };
     merged.worldbooks = { ...DEFAULT_SETTINGS.worldbooks, ...(saved?.worldbooks || {}) };
@@ -1353,12 +1393,70 @@ function danbooruToNai(tag) {
 // NovelAI API
 // ═══════════════════════════════════════════════════════════════════════════
 
-async function testApiConnection(apiKey) {
+// 后端发送：把 payload + 第三方 url + key 交给 ST server plugin，Node 端代发并返回 base64。
+async function generateViaBackend({ apiBaseUrl, apiKey, insecure, payload, signal }) {
+    let res;
+    try {
+        res = await fetch(NAI_BACKEND_GENERATE, {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            signal,
+            body: JSON.stringify({ url: apiBaseUrl || '', key: apiKey, insecure: !!insecure, payload }),
+        });
+    } catch (e) {
+        throw new NovelDrawError('后端代发失败（未安装 littlewhitebox-nai 插件或 SillyTavern 未开启 server plugins）', ErrorType.NETWORK);
+    }
+    if (res.status === 404) {
+        throw new NovelDrawError('后端端点不存在：请安装 plugins/littlewhitebox-nai 并在 config.yaml 开启 enableServerPlugins 后重启酒馆', ErrorType.NETWORK);
+    }
+    if (!res.ok) {
+        throw parseApiError(res.status, await res.text().catch(() => ''));
+    }
+    const data = await res.json().catch(() => null);
+    if (!data || data.ok !== true || !data.base64) {
+        const status = data?.status;
+        const msg = data?.error || '后端生图失败';
+        if (status) throw parseApiError(status, msg);
+        throw new NovelDrawError(msg, ErrorType.UNKNOWN);
+    }
+    return data.base64;
+}
+
+async function testApiConnection(apiKey, baseUrl, opts = {}) {
     if (!apiKey) throw new NovelDrawError('请填写 API Key', ErrorType.AUTH);
+    const settings = getSettings();
+    const sendMode = opts.sendMode || settings.sendMode || 'frontend';
+    const insecure = opts.insecure ?? settings.insecureTLS === true;
+    const resolvedBase = baseUrl ?? settings.apiBaseUrl;
     const controller = new AbortController();
     const tid = setTimeout(() => controller.abort(), API_TEST_TIMEOUT);
+
+    // 后端发送模式：走 server plugin 的 /test。
+    if (sendMode === 'backend') {
+        try {
+            const res = await fetch(NAI_BACKEND_TEST, {
+                method: 'POST',
+                headers: getRequestHeaders(),
+                signal: controller.signal,
+                body: JSON.stringify({ url: resolvedBase || '', key: apiKey, insecure: !!insecure }),
+            });
+            clearTimeout(tid);
+            if (res.status === 404) throw new NovelDrawError('后端端点不存在：请安装 plugins/littlewhitebox-nai 并开启 enableServerPlugins 后重启酒馆', ErrorType.NETWORK);
+            const data = await res.json().catch(() => null);
+            if (data?.ok === true) return { success: true };
+            if (data?.status === 401) throw new NovelDrawError('API Key 无效', ErrorType.AUTH);
+            throw new NovelDrawError(data?.error || `返回: ${res.status}`, ErrorType.NETWORK);
+        } catch (e) {
+            clearTimeout(tid);
+            if (e instanceof NovelDrawError) throw e;
+            throw handleFetchError(e);
+        }
+    }
+
+    // 前端直连模式。
+    const apiUrl = resolveNovelAIImageApi(resolvedBase);
     try {
-        const res = await fetch(NOVELAI_IMAGE_API, {
+        const res = await fetch(apiUrl, {
             method: 'POST',
             headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
             body: JSON.stringify({ input: 'test', model: 'nai-diffusion-3', action: 'generate', parameters: { width: 64, height: 64, steps: 1 } }),
@@ -1494,6 +1592,7 @@ async function generateNovelImage({ scene, characterPrompts, negativePrompt, par
             }
         }
 
+        const apiUrl = resolveNovelAIImageApi(settings.apiBaseUrl);
         const controller = new AbortController();
         const timeout = (settings.timeout > 0) ? settings.timeout : DEFAULT_SETTINGS.timeout;
         const tid = setTimeout(() => controller.abort(), timeout);
@@ -1503,20 +1602,30 @@ async function generateNovelImage({ scene, characterPrompts, negativePrompt, par
         }
 
         const t0 = Date.now();
+        const payload = buildNovelAIRequestBody({ scene, characterPrompts, negativePrompt, params: finalParams });
 
         try {
             if (signal?.aborted) throw new NovelDrawError('已取消', ErrorType.UNKNOWN);
 
-            const res = await fetch(NOVELAI_IMAGE_API, {
+            // 后端发送：交给 SillyTavern server plugin 代发，绕过浏览器 CORS / 自签证书。
+            if (settings.sendMode === 'backend') {
+                const base64 = await generateViaBackend({
+                    apiBaseUrl: settings.apiBaseUrl,
+                    apiKey: settings.apiKey,
+                    insecure: settings.insecureTLS === true,
+                    payload,
+                    signal: controller.signal,
+                });
+                console.log(`[NovelDraw] 完成(后端) ${Date.now() - t0}ms`);
+                return base64;
+            }
+
+            // 前端直连：浏览器直接请求 NovelAI / 第三方端点。
+            const res = await fetch(apiUrl, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${settings.apiKey}` },
                 signal: controller.signal,
-                body: JSON.stringify(buildNovelAIRequestBody({
-                    scene,
-                    characterPrompts,
-                    negativePrompt,
-                    params: finalParams
-                })),
+                body: JSON.stringify(payload),
             });
             if (!res.ok) throw parseApiError(res.status, await res.text().catch(() => ''));
             const buffer = await res.arrayBuffer();
@@ -3255,6 +3364,9 @@ async function sendInitData() {
             enabled: moduleInitialized,
             mode: settings.mode,
             apiKey: settings.apiKey,
+            apiBaseUrl: settings.apiBaseUrl || '',
+            sendMode: settings.sendMode || 'frontend',
+            insecureTLS: settings.insecureTLS === true,
             timeout: settings.timeout,
             requestDelay: settings.requestDelay,
             cacheDays: getSharedDrawSettings().cacheDays,
@@ -3380,6 +3492,15 @@ async function handleFrameMessage(event) {
                 if (typeof data.apiKey === 'string') {
                     settings.apiKey = data.apiKey.trim();
                 }
+                if (typeof data.apiBaseUrl === 'string') {
+                    settings.apiBaseUrl = data.apiBaseUrl.trim();
+                }
+                if (data.sendMode === 'frontend' || data.sendMode === 'backend') {
+                    settings.sendMode = data.sendMode;
+                }
+                if (typeof data.insecureTLS === 'boolean') {
+                    settings.insecureTLS = data.insecureTLS;
+                }
                 if (typeof data.timeout === 'number' && data.timeout > 0) {
                     settings.timeout = data.timeout;
                 }
@@ -3411,13 +3532,24 @@ async function handleFrameMessage(event) {
         case 'TEST_API': {
             try {
                 postStatus('loading', '测试中...', 'api');
-                await testApiConnection(data.apiKey);
+                await testApiConnection(data.apiKey, data.apiBaseUrl, {
+                    sendMode: data.sendMode,
+                    insecure: data.insecureTLS,
+                });
                 postStatus('success', '连接成功', 'api');
             } catch (e) {
                 postStatus('error', e?.message, 'api');
             }
             break;
         }
+
+        case 'CHECK_BACKEND_PLUGIN': {
+            const status = await checkBackendPluginStatus();
+            const iframe = document.getElementById('xiaobaix-novel-draw-iframe');
+            if (iframe) postToIframe(iframe, { type: 'BACKEND_PLUGIN_STATUS', status }, 'LittleWhiteBox-NovelDraw');
+            break;
+        }
+
 
         case 'SAVE_PARAMS_PRESET': {
             const ok = await updateSettingsPersistent((settings) => {

--- a/server-plugin/littlewhitebox-nai/README.md
+++ b/server-plugin/littlewhitebox-nai/README.md
@@ -1,0 +1,63 @@
+# LittleWhiteBox NovelAI 后端转发插件
+
+这是 **LittleWhiteBox** 绘图模块的可选**后端插件**（SillyTavern Server Plugin）。
+
+安装后，NovelAI 绘图的「发送方式」就能选 **后端发送**，由 SillyTavern 后端（Node）代发请求，
+从而**绕过浏览器的 CORS 限制与自签证书限制**，可正常使用需要 CORS 白名单/证书受限的第三方中转端点。
+
+> 不装此插件也能用「前端直连」；只有在浏览器直连被 CORS / 证书拦截时才需要它。
+
+---
+
+## 安装步骤（三步）
+
+### 1. 放置插件文件夹
+把本文件夹 `littlewhitebox-nai/` 整个复制/剪切到 SillyTavern 的 **后端插件目录**：
+
+```
+SillyTavern/plugins/littlewhitebox-nai/
+```
+
+放好后目录里应包含：`index.js`、`package.json`、`manifest.json`、`README.md`。
+
+> 注意：不是 `public/scripts/extensions/`（那是前端扩展目录），而是 SillyTavern 根目录下的 `plugins/`。
+
+### 2. 开启 server plugins
+编辑 SillyTavern 根目录的 `config.yaml`，把下面这行改为 `true`（没有就新增）：
+
+```yaml
+enableServerPlugins: true
+```
+
+### 3. 重启 SillyTavern
+重启后，启动日志里应出现：
+
+```
+[littlewhitebox-nai] server plugin initialized (v1.0.0)
+```
+
+回到 LittleWhiteBox 的 NovelAI 绘图设置 →「API 配置」→「发送方式」点「后端发送」，
+状态栏应显示 🟢 已就绪，点「测试连接」通过即可正常生图。
+
+---
+
+## 提供的接口
+
+由 SillyTavern 自动挂载到 `/api/plugins/littlewhitebox-nai/`：
+
+| 方法 | 路径 | 说明 |
+|---|---|---|
+| GET | `/status` | 前端检测插件是否就绪 |
+| POST | `/generate-image` | 代发 NovelAI 生图请求，返回图片 base64 |
+| POST | `/test` | 测试第三方端点连通性 |
+
+`generate-image` / `test` 请求体：`{ url?, key, payload?, insecure? }`
+- `url`：第三方端点根地址（留空 = 官方 `https://image.novelai.net`）
+- `key`：NovelAI API Key
+- `insecure`：为 `true` 时后端忽略 TLS 证书校验（仅连接自签证书端点时使用）
+
+---
+
+## 安全说明
+- 本插件只做「把前端给定的 payload + key 转发到 NovelAI/第三方端点并回传图片」，不落盘、不改配置。
+- `insecure` 会在单次请求内临时放宽 TLS 校验，请仅在信任的自签证书端点上使用。

--- a/server-plugin/littlewhitebox-nai/index.js
+++ b/server-plugin/littlewhitebox-nai/index.js
@@ -1,0 +1,177 @@
+'use strict';
+
+/**
+ * LittleWhiteBox NovelAI 后端转发插件 (SillyTavern Server Plugin)
+ *
+ * 作用：把 LittleWhiteBox 绘图模块的 NovelAI 图片生成请求交给 SillyTavern 后端（Node）代发，
+ * 从而绕过浏览器的 CORS 限制与自签证书限制，支持第三方中转端点（如 touhounai.xyz）。
+ *
+ * 安装：把本文件夹整个放到 SillyTavern/plugins/littlewhitebox-nai/ ，
+ *       在 config.yaml 中开启 enableServerPlugins: true ，然后重启 SillyTavern。
+ *
+ * 路由（由 ST 自动挂载到 /api/plugins/<id>）：
+ *   GET  /api/plugins/littlewhitebox-nai/status
+ *     resp: { ok:true, id, version }               —— 供前端检测插件是否就绪
+ *   POST /api/plugins/littlewhitebox-nai/generate-image
+ *     body: { url?, key, payload, insecure? }
+ *     resp: { ok:true, base64 } 或 { ok:false, error, status }
+ *   POST /api/plugins/littlewhitebox-nai/test
+ *     body: { url?, key, insecure? }
+ *     resp: { ok:true } 或 { ok:false, error, status }
+ */
+
+const PLUGIN_VERSION = '1.0.0';
+const NOVELAI_DEFAULT_BASE_URL = 'https://image.novelai.net';
+
+function resolveImageApi(baseUrl) {
+    const raw = String(baseUrl || '').trim();
+    if (!raw) return `${NOVELAI_DEFAULT_BASE_URL}/ai/generate-image`;
+    const trimmed = raw.replace(/\/+$/, '');
+    if (/\/ai\/generate-image$/i.test(trimmed)) return trimmed;
+    return `${trimmed}/ai/generate-image`;
+}
+
+/**
+ * 从 NovelAI 返回的 zip buffer 中取出第一张图片并转 base64。
+ * 官方及大多数中转返回含单张 PNG 的 zip；若非 zip（个别中转直接返回裸图），退回原始二进制 base64。
+ * 仅依赖 Node 内置 zlib，无第三方依赖。
+ */
+function extractImageBase64(buffer) {
+    const buf = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
+    const isZip = buf.length > 4 && buf[0] === 0x50 && buf[1] === 0x4B && buf[2] === 0x03 && buf[3] === 0x04;
+    if (!isZip) {
+        return buf.toString('base64');
+    }
+    const zlib = require('node:zlib');
+    let offset = 0;
+    while (offset + 30 <= buf.length) {
+        const sig = buf.readUInt32LE(offset);
+        if (sig !== 0x04034b50) break;
+        const method = buf.readUInt16LE(offset + 8);
+        const compSize = buf.readUInt32LE(offset + 18);
+        const nameLen = buf.readUInt16LE(offset + 26);
+        const extraLen = buf.readUInt16LE(offset + 28);
+        const nameStart = offset + 30;
+        const name = buf.toString('utf8', nameStart, nameStart + nameLen).toLowerCase();
+        const dataStart = nameStart + nameLen + extraLen;
+        const isImage = /\.(png|jpe?g|webp)$/.test(name);
+        if (isImage && compSize > 0) {
+            const compData = buf.subarray(dataStart, dataStart + compSize);
+            let raw;
+            if (method === 0) {
+                raw = compData;
+            } else if (method === 8) {
+                raw = zlib.inflateRawSync(compData);
+            } else {
+                throw new Error(`Unsupported zip compression method ${method}`);
+            }
+            return Buffer.from(raw).toString('base64');
+        }
+        if (compSize === 0) break;
+        offset = dataStart + compSize;
+    }
+    throw new Error('No image entry found in NovelAI zip response');
+}
+
+async function doFetch(url, options, insecure) {
+    // Node 18+ 自带全局 fetch。insecure=true 时临时放宽 TLS 校验（用于自签证书的第三方端点）。
+    const prev = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    if (insecure) process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    try {
+        return await fetch(url, options);
+    } finally {
+        if (insecure) {
+            if (prev === undefined) delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+            else process.env.NODE_TLS_REJECT_UNAUTHORIZED = prev;
+        }
+    }
+}
+
+const info = {
+    id: 'littlewhitebox-nai',
+    name: 'LittleWhiteBox NovelAI Backend Proxy',
+    version: PLUGIN_VERSION,
+    description: 'Backend passthrough for LittleWhiteBox NovelAI image generation (bypass CORS / self-signed cert).',
+};
+
+/**
+ * @param {import('express').Router} router
+ */
+async function init(router) {
+    router.get('/status', (_req, res) => {
+        res.status(200).send({ ok: true, id: info.id, version: PLUGIN_VERSION });
+    });
+
+    router.post('/generate-image', async (req, res) => {
+        try {
+            const body = req.body || {};
+            const key = String(body.key || '').trim();
+            const payload = body.payload;
+            const insecure = body.insecure === true;
+            if (!key) return res.status(400).send({ ok: false, error: 'API key is required' });
+            if (!payload || typeof payload !== 'object') return res.status(400).send({ ok: false, error: 'payload is required' });
+
+            const apiUrl = resolveImageApi(body.url);
+            const upstream = await doFetch(apiUrl, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${key}`,
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/zip, application/octet-stream, image/*, */*',
+                },
+                body: JSON.stringify(payload),
+            }, insecure);
+
+            if (!upstream.ok) {
+                const text = await upstream.text().catch(() => '');
+                console.warn(`[littlewhitebox-nai] upstream ${upstream.status}: ${String(text).slice(0, 300)}`);
+                return res.status(200).send({ ok: false, status: upstream.status, error: text || `HTTP ${upstream.status}` });
+            }
+
+            const arrayBuf = await upstream.arrayBuffer();
+            const base64 = extractImageBase64(Buffer.from(arrayBuf));
+            return res.status(200).send({ ok: true, base64 });
+        } catch (error) {
+            console.error('[littlewhitebox-nai] generate-image error:', error);
+            return res.status(200).send({ ok: false, error: String(error?.message || error) });
+        }
+    });
+
+    router.post('/test', async (req, res) => {
+        try {
+            const body = req.body || {};
+            const key = String(body.key || '').trim();
+            const insecure = body.insecure === true;
+            if (!key) return res.status(400).send({ ok: false, error: 'API key is required' });
+
+            const apiUrl = resolveImageApi(body.url);
+            const upstream = await doFetch(apiUrl, {
+                method: 'POST',
+                headers: { 'Authorization': `Bearer ${key}`, 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    input: 'test',
+                    model: 'nai-diffusion-3',
+                    action: 'generate',
+                    parameters: { width: 64, height: 64, steps: 1, n_samples: 1 },
+                }),
+            }, insecure);
+
+            // 400/402 视为“连通”（鉴权通过但参数/额度问题），401 视为 key 无效。
+            if (upstream.status === 401) {
+                return res.status(200).send({ ok: false, status: 401, error: 'API Key 无效' });
+            }
+            if (upstream.ok || upstream.status === 400 || upstream.status === 402) {
+                return res.status(200).send({ ok: true });
+            }
+            const text = await upstream.text().catch(() => '');
+            return res.status(200).send({ ok: false, status: upstream.status, error: text || `HTTP ${upstream.status}` });
+        } catch (error) {
+            console.error('[littlewhitebox-nai] test error:', error);
+            return res.status(200).send({ ok: false, error: String(error?.message || error) });
+        }
+    });
+
+    console.log('[littlewhitebox-nai] server plugin initialized (v' + PLUGIN_VERSION + ')');
+}
+
+module.exports = { info, init };

--- a/server-plugin/littlewhitebox-nai/manifest.json
+++ b/server-plugin/littlewhitebox-nai/manifest.json
@@ -1,0 +1,7 @@
+{
+    "id": "littlewhitebox-nai",
+    "name": "LittleWhiteBox NovelAI Backend Proxy",
+    "version": "1.0.0",
+    "author": "LittleWhiteBox",
+    "description": "SillyTavern 后端转发插件：为 LittleWhiteBox 绘图模块的 NovelAI 图片生成提供后端代发，绕过浏览器 CORS 与自签证书限制。"
+}

--- a/server-plugin/littlewhitebox-nai/package.json
+++ b/server-plugin/littlewhitebox-nai/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "littlewhitebox-nai",
+    "version": "1.0.0",
+    "type": "commonjs",
+    "main": "index.js",
+    "description": "Backend passthrough for LittleWhiteBox NovelAI image generation (bypass CORS / self-signed cert).",
+    "private": true
+}


### PR DESCRIPTION
# PR:NovelAI 绘图支持第三方端点与后端发送模式

## 背景

LittleWhiteBox 的 NovelAI 绘图此前只能走浏览器前端 `fetch` 直连官方端点。用户在使用第三方中转端点时会遇到两类浏览器层面的限制:

- **CORS 拦截**:中转端未在响应中放行当前来源(`Access-Control-Allow-Origin`)
- **证书错误**:中转端使用自签/无效证书(`ERR_CERT_AUTHORITY_INVALID`)

这两类问题是浏览器安全策略造成的,前端无法绕过。本次为 NovelAI 绘图增加**第三方端点配置**与**后端发送模式**,由 SillyTavern 后端代发请求以绕过上述限制。

## 改动内容

### 1. 新增第三方端点 URL 配置

- API 配置页新增「第三方端点 URL(可选)」输入框,旁边带**重置按钮**(一键清空回官方地址)
- URL 规范化逻辑(前后端一致):
  - 留空 → 官方端点 `https://image.novelai.net/ai/generate-image`
  - 只填根地址(如 `https://xxx.com`)→ 自动追加 `/ai/generate-image`
  - 已含 `/ai/generate-image` → 原样使用

### 2. 新增「发送方式」切换

API 配置页新增两个单选按钮:

- **前端直连**(默认):保持原有浏览器 `fetch` 直连行为,需对方支持 CORS + 有效证书
- **后端发送**:由 SillyTavern 后端(Node)代发,绕过浏览器 CORS 与自签证书限制

另提供「忽略证书验证」勾选项(仅后端发送模式、连接自签证书端点时使用)。

### 3. 新增 SillyTavern Server Plugin(后端转发插件)

新增独立后端插件目录 `server-plugin/littlewhitebox-nai/`,随扩展一起分发:

| 文件 | 说明 |
|---|---|
| `index.js` | 后端转发实现,零第三方依赖 |
| `package.json` / `manifest.json` | ST server plugin 规范文件 | | `README.md` | 中文安装说明 |

插件挂载路由(由 ST 自动挂到 `/api/plugins/littlewhitebox-nai/`):

- `GET /status` — 供前端探测插件就绪状态
- `POST /generate-image` — 代发 NovelAI 生图请求,返回图片 base64
- `POST /test` — 测试端点连通性

### 4. 前端后端状态栏 + 文案引导(纯手动安装)

由于 SillyTavern 出于安全禁止前端扩展写服务器文件、改 config、重启进程,后端插件无法自动安装。因此前端在「后端发送」模式下提供:

- **状态栏**:自动探测 `/status`,显示 🟢已就绪 / 🔴未就绪,含「重新检测」按钮
  - 就绪 → 显示插件版本
  - 404 → 提示未安装
  - 连接失败 → 提示可能未开启 `enableServerPlugins`
- **未就绪时展开四步文字引导**:说明插件文件夹位置 → 复制到 `SillyTavern/plugins/littlewhitebox-nai/` → 改 `config.yaml` 的 `enableServerPlugins: true` → 重启后重新检测

## 涉及文件

| 文件 | 改动 |
|---|---|
| `modules/draw/providers/novelai/novel-draw.js` | 新增 `apiBaseUrl` / `sendMode` / `insecureTLS` 设置(`CONFIG_VERSION` 升至 7);新增 `resolveNovelAIImageApi` / `generateViaBackend` / `checkBackendPluginStatus`;`generateNovelImage` / `testApiConnection` 按发送方式分流;`SAVE_API_CONFIG` / `TEST_API` / `sendInitData` / `CHECK_BACKEND_PLUGIN` 消息处理 | | `modules/draw/providers/novelai/novel-draw.html` | API 配置卡新增第三方 URL 输入框+重置按钮、发送方式单选、忽略证书勾选、后端状态栏与安装引导;对应 state 字段、样式与事件绑定 | | `server-plugin/littlewhitebox-nai/index.js` | 新增后端转发插件 | | `server-plugin/littlewhitebox-nai/package.json` | 新增 | | `server-plugin/littlewhitebox-nai/manifest.json` | 新增 | | `server-plugin/littlewhitebox-nai/README.md` | 新增中文安装说明 |

## 兼容性

- `CONFIG_VERSION` 新增字段默认值(`apiBaseUrl=''`、`sendMode='frontend'`、`insecureTLS=false`)向后兼容,不影响老用户既有行为
- 默认发送方式为「前端直连」,不安装后端插件不影响原有使用
- 后端插件为可选功能,仅在浏览器直连被 CORS/证书拦截时才需要