### PR TITLE
feat: 支持 TauriTavern ChatSurface

### DIFF
--- a/core/constants.js
+++ b/core/constants.js
@@ -14,3 +14,18 @@ export const EXT_FOLDER_ID = (() => {
     }
 })();
 export const extensionFolderPath = `scripts/extensions/third-party/${EXT_FOLDER_ID}`;
+
+// Read once before any legacy renderer/observer can start.
+export const MANAGED_CHAT_SURFACE = (() => {
+    const host = globalThis.window?.__TAURITAVERN__;
+    if (!host) return false;
+    const api = host.api?.chatSurface;
+    if (typeof api?.isManagedOwnershipRequired !== 'function') {
+        throw new Error('TauriTavern ChatSurface ownership query is unavailable');
+    }
+    const required = api.isManagedOwnershipRequired();
+    if (typeof required !== 'boolean') {
+        throw new TypeError('ChatSurface ownership query must return a boolean');
+    }
+    return required;
+})();

--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
 import { extension_settings, extensionTypes } from "../../../extensions.js";
 import { saveSettingsDebounced, eventSource, event_types, getRequestHeaders } from "../../../../script.js";
-import { EXT_FOLDER_ID, EXT_ID, extensionFolderPath } from "./core/constants.js";
+import { EXT_FOLDER_ID, EXT_ID, MANAGED_CHAT_SURFACE, extensionFolderPath } from "./core/constants.js";
 import { executeSlashCommand } from "./core/slash-command.js";
 import { EventCenter } from "./core/event-manager.js";
 import { initTasks } from "./modules/scheduled-tasks/scheduled-tasks.js";
-import { initMessagePreview, addHistoryButtonsDebounced } from "./modules/message-preview.js";
+import { initMessagePreview, addHistoryButtonsDebounced, mountManagedHistoryButton } from "./modules/message-preview.js";
 import { initImmersiveMode } from "./modules/immersive-mode.js";
-import { initTemplateEditor } from "./modules/template-editor/template-editor.js";
+import { hasActiveCustomTemplate, hasCustomTemplateForMessage, initTemplateEditor } from "./modules/template-editor/template-editor.js";
 import { initFourthWall, initFourthWallFloorTools, refreshFourthWallFloorTools, closeFourthWall, openFourthWall } from "./modules/fourth-wall/fourth-wall.js";
-import { initButtonCollapse } from "./widgets/button-collapse.js";
-import { initVariablesPanel, cleanupVariablesPanel } from "./modules/variables/variables-panel.js";
+import { initButtonCollapse, mountManagedButtonCollapse } from "./widgets/button-collapse.js";
+import { initVariablesPanel, cleanupVariablesPanel, mountManagedVariablesButton } from "./modules/variables/variables-panel.js";
 import { initStreamingGeneration } from "./modules/streaming-generation.js";
 import { initVariablesCore, cleanupVariablesCore } from "./modules/variables/variables-core.js";
 import { initControlAudio } from "./modules/control-audio.js";
@@ -19,7 +19,8 @@ import {
     processExistingMessages,
     clearBlobCaches,
     renderHtmlInIframe,
-    shrinkRenderedWindowFull
+    shrinkRenderedWindowFull,
+    claimManagedIframeRuntimes,
 } from "./modules/iframe-renderer.js";
 import { initVarCommands, cleanupVarCommands } from "./modules/variables/var-commands.js";
 import { initVareventEditor, cleanupVareventEditor } from "./modules/variables/varevent-editor.js";
@@ -33,7 +34,7 @@ import {
     clearSharedImageRequests as clearSharedImageRequestsRuntime,
     generateSharedImage as generateSharedImageRuntime,
 } from "./modules/draw/shared/generated-image-runtime.js";
-import "./modules/story-summary/story-summary.js";
+import { mountManagedStorySummaryButton } from "./modules/story-summary/story-summary.js";
 import "./modules/story-outline/story-outline.js";
 import { initTts, cleanupTts } from "./modules/tts/tts.js";
 import { initEnaPlanner, cleanupEnaPlanner } from "./modules/ena-planner/ena-planner.js";
@@ -70,6 +71,69 @@ if (settings.dynamicPrompt && !settings.fourthWall) settings.fourthWall = settin
 settings.audio ||= {};
 settings.audio.enabled = true;
 settings.wrapperIframe = true;
+
+function mountManagedDecorators({ element, mesid }) {
+    if (!settings.enabled) return;
+    if (hasCustomTemplateForMessage(mesid)) {
+        throw new Error('LittleWhiteBox bounded ChatSurface does not support custom template iframes');
+    }
+    const releases = [];
+    const release = () => {
+        let firstError;
+        for (let index = releases.length - 1; index >= 0; index -= 1) {
+            try { releases[index]?.(); } catch (error) { firstError ??= error; }
+        }
+        releases.length = 0;
+        if (firstError !== undefined) throw firstError;
+    };
+
+    try {
+        releases.push(mountManagedHistoryButton(element, mesid));
+        releases.push(mountManagedVariablesButton(element, mesid));
+        releases.push(mountManagedStorySummaryButton(element, mesid));
+        releases.push(mountManagedButtonCollapse(element));
+    } catch (error) {
+        try { release(); } catch (cleanupError) {
+            const failure = new Error('LittleWhiteBox managed decorator mount and cleanup failed');
+            failure.cause = error;
+            failure.cleanupError = cleanupError;
+            throw failure;
+        }
+        throw error;
+    }
+    return release;
+}
+
+function assertManagedSettingsCompatible() {
+    if (!settings.enabled) return;
+    const unsupported = [
+        ['immersive mode', settings.immersive?.enabled],
+        ['message preview/purge', settings.preview?.enabled],
+        ['story-outline floor tools', settings.storyOutline?.enabled],
+        ['TTS floor tools', settings.tts?.enabled],
+        ['fourth-wall floor tools', settings.fourthWall?.enabled],
+        ['draw provider', normalizeDrawProvider(settings.drawProvider) !== 'disabled'],
+        ['custom template iframe', hasActiveCustomTemplate()],
+    ].filter(([, enabled]) => enabled).map(([name]) => name);
+    if (unsupported.length > 0) {
+        throw new Error(`LittleWhiteBox bounded ChatSurface does not support: ${unsupported.join(', ')}`);
+    }
+}
+
+export function activate() {
+    if (!MANAGED_CHAT_SURFACE) return;
+    assertManagedSettingsCompatible();
+    const api = window.__TAURITAVERN__?.api?.chatSurface;
+    if (api?.protocolVersion !== 1 || typeof api.registerParticipant !== 'function') {
+        throw new Error('TauriTavern ChatSurface participant v1 API is unavailable');
+    }
+    api.registerParticipant({
+        id: 'littlewhitebox/message-runtime',
+        protocolVersion: 1,
+        claimRuntimes: claimManagedIframeRuntimes,
+        didMount: mountManagedDecorators,
+    });
+}
 
 const DRAW_PROVIDER_VALUES = new Set(['disabled', 'novelai', 'sdwebui', 'comfyui']);
 let tavernModulePromise = null;
@@ -734,9 +798,9 @@ function cleanupAllResources() {
         } catch (e) { }
     });
     moduleCleanupFunctions.clear();
-    try {
-        cleanupRenderer();
-    } catch (e) { }
+    if (!MANAGED_CHAT_SURFACE) {
+        try { cleanupRenderer(); } catch (e) { }
+    }
     document.querySelectorAll('.memory-button, .mes_history_preview').forEach(btn => btn.remove());
     document.querySelectorAll('#message_preview_btn').forEach(btn => {
         if (btn instanceof HTMLElement) {
@@ -774,6 +838,28 @@ function toggleSettingsControls(enabled) {
     });
     document.getElementById('xiaobaix-disabled-style')?.remove();
     syncFeatureActionButtons();
+}
+
+function lockManagedSettingsControls() {
+    if (!MANAGED_CHAT_SURFACE) return;
+    const reason = 'TauriTavern bounded ChatSurface 当前会话已冻结此设置；请先关闭聊天虚拟化并重新加载。';
+    const ids = [
+        'xiaobaix_enabled', 'xiaobaix_recorded_enabled', 'xiaobaix_preview_enabled',
+        'xiaobaix_template_enabled', 'xiaobaix_immersive_enabled',
+        'xiaobaix_variables_panel_enabled', 'xiaobaix_story_summary_enabled',
+        'xiaobaix_story_outline_enabled', 'xiaobaix_fourth_wall_open_settings',
+        'xiaobaix_draw_provider', 'xiaobaix_draw_open_settings',
+        'xiaobaix_tts_enabled', 'xiaobaix_tts_open_settings',
+        'xiaobaix_render_enabled', 'xiaobaix_max_rendered', 'xiaobaix_reset_btn',
+    ];
+    ids.forEach(id => {
+        const element = document.getElementById(id);
+        if (!element) return;
+        element.setAttribute('aria-disabled', 'true');
+        element.setAttribute('title', reason);
+        element.disabled = true;
+        element.classList.add('disabled-control');
+    });
 }
 
 function syncFeatureActionButtons() {
@@ -814,6 +900,7 @@ function syncFeatureActionButtons() {
         drawButton.disabled = !isXiaobaixEnabled;
         drawButton.classList.toggle('disabled-action', !isXiaobaixEnabled);
     }
+    lockManagedSettingsControls();
 }
 
 async function toggleAllFeatures(enabled) {
@@ -821,36 +908,38 @@ async function toggleAllFeatures(enabled) {
         toggleSettingsControls(true);
         try { window.XB_applyPrevStates && window.XB_applyPrevStates(); } catch (e) { }
         saveSettingsDebounced();
-        initRenderer();
+        if (!MANAGED_CHAT_SURFACE) initRenderer();
         try { initVarCommands(); } catch (e) { }
         try { initVareventEditor(); } catch (e) { }
         if (extension_settings[EXT_ID].tasks?.enabled) {
             await initTasks();
         }
         const moduleInits = [
-            { condition: extension_settings[EXT_ID].immersive?.enabled, init: initImmersiveMode },
-            { condition: extension_settings[EXT_ID].templateEditor?.enabled, init: initTemplateEditor },
+            { condition: !MANAGED_CHAT_SURFACE && extension_settings[EXT_ID].immersive?.enabled, init: initImmersiveMode },
+            { condition: !MANAGED_CHAT_SURFACE && extension_settings[EXT_ID].templateEditor?.enabled, init: initTemplateEditor },
             { condition: true, init: initControlAudio },
             { condition: extension_settings[EXT_ID].variablesPanel?.enabled, init: initVariablesPanel },
             { condition: extension_settings[EXT_ID].variablesCore?.enabled, init: initVariablesCore },
-            { condition: extension_settings[EXT_ID].tts?.enabled, init: initTts },
+            { condition: !MANAGED_CHAT_SURFACE && extension_settings[EXT_ID].tts?.enabled, init: initTts },
             { condition: extension_settings[EXT_ID].enaPlanner?.enabled, init: initEnaPlanner },
             { condition: true, init: initEbook },
             { condition: true, init: () => { void initTavernSafely(); } },
             { condition: true, init: initStreamingGeneration },
-            { condition: true, init: initButtonCollapse }
+            { condition: !MANAGED_CHAT_SURFACE, init: initButtonCollapse }
         ];
         moduleInits.forEach(({ condition, init }) => {
             if (condition) init();
         });
-        try {
-            await initActiveDrawProvider();
-        } catch (e) {
-            console.error('[LittleWhiteBox] 初始化画图 provider 失败:', e);
-        }
-        try { initFourthWallFloorTools(); } catch (e) { }
-        if (extension_settings[EXT_ID].fourthWall?.enabled) {
-            try { initFourthWall(); } catch (e) { }
+        if (!MANAGED_CHAT_SURFACE) {
+            try {
+                await initActiveDrawProvider();
+            } catch (e) {
+                console.error('[LittleWhiteBox] 初始化画图 provider 失败:', e);
+            }
+            try { initFourthWallFloorTools(); } catch (e) { }
+            if (extension_settings[EXT_ID].fourthWall?.enabled) {
+                try { initFourthWall(); } catch (e) { }
+            }
         }
         if (extension_settings[EXT_ID].preview?.enabled || extension_settings[EXT_ID].recorded?.enabled) {
             setTimeout(initMessagePreview, 200);
@@ -1082,6 +1171,7 @@ async function setupSettings() {
 
         $("#xiaobaix_render_enabled").prop("checked", settings.renderEnabled !== false).on("change", async function () {
             if (!isXiaobaixEnabled) return;
+            if (MANAGED_CHAT_SURFACE) return;
             const wasEnabled = settings.renderEnabled !== false;
             settings.renderEnabled = $(this).prop("checked");
             saveSettingsDebounced();
@@ -1107,6 +1197,7 @@ async function setupSettings() {
             .val(Number.isFinite(settings.maxRenderedMessages) ? settings.maxRenderedMessages : 5)
             .on("input change", function () {
                 if (!isXiaobaixEnabled) return;
+                if (MANAGED_CHAT_SURFACE) return;
                 const v = normalizeMaxRendered($(this).val());
                 $(this).val(v);
                 settings.maxRenderedMessages = v;
@@ -1117,6 +1208,7 @@ async function setupSettings() {
         $(document).off('click.xbreset', '#xiaobaix_reset_btn').on('click.xbreset', '#xiaobaix_reset_btn', async function (e) {
             e.preventDefault();
             e.stopPropagation();
+            if (MANAGED_CHAT_SURFACE) return;
             const MAP = {
                 recorded: 'xiaobaix_recorded_enabled',
                 immersive: 'xiaobaix_immersive_enabled',
@@ -1156,6 +1248,7 @@ async function setupSettings() {
             settings.audio.enabled = true;
             try { saveSettingsDebounced(); } catch (e) { }
         });
+        lockManagedSettingsControls();
     } catch (err) { }
 }
 
@@ -1209,8 +1302,10 @@ function setupMenuTabs() {
     }, 300);
 }
 
-window.processExistingMessages = processExistingMessages;
-window.renderHtmlInIframe = renderHtmlInIframe;
+if (!MANAGED_CHAT_SURFACE) {
+    window.processExistingMessages = processExistingMessages;
+    window.renderHtmlInIframe = renderHtmlInIframe;
+}
 window.registerModuleCleanup = registerModuleCleanup;
 window.updateLittleWhiteBoxExtension = updateLittleWhiteBoxExtension;
 window.removeAllUpdateNotices = removeAllUpdateNotices;
@@ -1238,7 +1333,7 @@ jQuery(async () => {
 
         try { initControlAudio(); } catch (e) { }
 
-        if (isXiaobaixEnabled) {
+        if (isXiaobaixEnabled && !MANAGED_CHAT_SURFACE) {
             initRenderer();
         }
 
@@ -1270,26 +1365,28 @@ jQuery(async () => {
             }
 
             const moduleInits = [
-                { condition: settings.immersive?.enabled, init: initImmersiveMode },
-                { condition: settings.templateEditor?.enabled, init: initTemplateEditor },
+                { condition: !MANAGED_CHAT_SURFACE && settings.immersive?.enabled, init: initImmersiveMode },
+                { condition: !MANAGED_CHAT_SURFACE && settings.templateEditor?.enabled, init: initTemplateEditor },
                 { condition: settings.variablesPanel?.enabled, init: initVariablesPanel },
                 { condition: settings.variablesCore?.enabled, init: initVariablesCore },
-                { condition: settings.tts?.enabled, init: initTts },
+                { condition: !MANAGED_CHAT_SURFACE && settings.tts?.enabled, init: initTts },
                 { condition: settings.enaPlanner?.enabled, init: initEnaPlanner },
                 { condition: true, init: initEbook },
                 { condition: true, init: () => { void initTavernSafely(); } },
                 { condition: true, init: initStreamingGeneration },
-                { condition: true, init: initButtonCollapse }
+                { condition: !MANAGED_CHAT_SURFACE, init: initButtonCollapse }
             ];
             moduleInits.forEach(({ condition, init }) => { if (condition) init(); });
-            try {
-                await initActiveDrawProvider();
-            } catch (e) {
-                console.error('[LittleWhiteBox] 初始化画图 provider 失败:', e);
-            }
-            try { initFourthWallFloorTools(); } catch (e) { }
-            if (settings.fourthWall?.enabled) {
-                try { initFourthWall(); } catch (e) { }
+            if (!MANAGED_CHAT_SURFACE) {
+                try {
+                    await initActiveDrawProvider();
+                } catch (e) {
+                    console.error('[LittleWhiteBox] 初始化画图 provider 失败:', e);
+                }
+                try { initFourthWallFloorTools(); } catch (e) { }
+                if (settings.fourthWall?.enabled) {
+                    try { initFourthWall(); } catch (e) { }
+                }
             }
 
             if (settings.preview?.enabled || settings.recorded?.enabled) {
@@ -1305,9 +1402,11 @@ jQuery(async () => {
             }
         }, 2000);
 
-        setInterval(() => {
-            if (isXiaobaixEnabled) processExistingMessages();
-        }, 30000);
+        if (!MANAGED_CHAT_SURFACE) {
+            setInterval(() => {
+                if (isXiaobaixEnabled) processExistingMessages();
+            }, 30000);
+        }
     } catch (err) { }
 });
 

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ export function activate() {
     api.registerParticipant({
         id: 'littlewhitebox/message-runtime',
         protocolVersion: 1,
-        claimRuntimes: claimManagedIframeRuntimes,
+        prepareContent: claimManagedIframeRuntimes,
         didMount: mountManagedDecorators,
     });
 }

--- a/manifest.json
+++ b/manifest.json
@@ -8,5 +8,8 @@
     "author": "biex",
     "version": "3.0.3",
     "homePage": "https://github.com/RT15548/LittleWhiteBox",
-    "generate_interceptor": "xiaobaixGenerateInterceptor"
+    "generate_interceptor": "xiaobaixGenerateInterceptor",
+    "hooks": {
+        "activate": "activate"
+    }
 }

--- a/modules/iframe-renderer.js
+++ b/modules/iframe-renderer.js
@@ -21,6 +21,8 @@ const BLOB_CACHE_LIMIT = 32;
 let lastApplyTs = 0;
 let pendingHeight = null;
 let pendingRec = null;
+let messageListenerBound = false;
+let managedRuntimeCount = 0;
 
 CacheRegistry.register(MODULE_ID, {
     name: 'Blob URL 缓存',
@@ -162,19 +164,20 @@ function extractExternalUrl(content) {
     return null;
 }
 
-async function fetchExternalHtml(url) {
+async function fetchExternalHtml(url, signal) {
     try {
-        const r = await fetch(url, { mode: 'cors' });
+        const r = await fetch(url, { mode: 'cors', signal });
         if (r.ok) return await r.text();
     } catch (_) {}
     return null;
 }
 
-async function loadExternalUrl(iframe, url, settings) {
+async function loadExternalUrl(iframe, url, settings, { signal, scheduleTimeout = setTimeout } = {}) {
     try {
         iframe.srcdoc = '<!DOCTYPE html><html><body style="display:flex;justify-content:center;align-items:center;height:100px;color:#888;font-family:sans-serif;background:transparent">加载中...</body></html>';
 
-        let html = await fetchExternalHtml(url);
+        let html = await fetchExternalHtml(url, signal);
+        if (signal?.aborted) return;
 
         if (html && settings.variablesCore?.enabled && typeof replaceXbGetVarInString === 'function') {
             try {
@@ -185,14 +188,8 @@ async function loadExternalUrl(iframe, url, settings) {
         }
 
         if (html) {
-            const full = buildWrappedHtml(html);
-            if (settings.useBlob) {
-                const codeHash = djb2(html);
-                setIframeBlobHTML(iframe, full, codeHash);
-            } else {
-                iframe.srcdoc = full;
-            }
-            setTimeout(() => {
+            setIframeContent(iframe, html, settings);
+            scheduleTimeout(() => {
                 try {
                     const targetOrigin = getIframeTargetOrigin(iframe);
                     postToIframe(iframe, { type: 'probe' }, null, targetOrigin);
@@ -205,6 +202,7 @@ async function loadExternalUrl(iframe, url, settings) {
             iframe.setAttribute('scrolling', 'auto');
         }
     } catch (err) {
+        if (signal?.aborted) return;
         console.error('[iframeRenderer] 外部URL加载失败:', err);
         iframe.removeAttribute('srcdoc');
         iframe.src = url;
@@ -243,6 +241,176 @@ ${vhFix}
 <style>html,body{margin:0;padding:0;background:transparent}</style>
 </head>
 <body>${html}</body></html>`;
+}
+
+function acquireManagedMessageListener() {
+    if (!messageListenerBound) {
+        // eslint-disable-next-line no-restricted-syntax -- messages require an exact live iframe winMap entry.
+        window.addEventListener('message', handleIframeMessage);
+        messageListenerBound = true;
+    }
+    managedRuntimeCount += 1;
+}
+
+function releaseManagedMessageListener() {
+    managedRuntimeCount -= 1;
+    if (managedRuntimeCount === 0 && messageListenerBound) {
+        window.removeEventListener('message', handleIframeMessage);
+        messageListenerBound = false;
+    }
+}
+
+function createRenderIframe() {
+    const iframe = document.createElement('iframe');
+    iframe.id = generateUniqueId();
+    iframe.className = 'xiaobaix-iframe';
+    iframe.style.cssText = 'width:100%;border:none;background:transparent;overflow:hidden;height:0;margin:0;padding:0;display:block;contain:layout paint style;will-change:height;min-height:50px';
+    iframe.setAttribute('frameborder', '0');
+    iframe.setAttribute('scrolling', 'no');
+    iframe.loading = 'eager';
+    return iframe;
+}
+
+function setIframeContent(iframe, html, settings) {
+    const full = buildWrappedHtml(html);
+    if (settings.useBlob) {
+        setIframeBlobHTML(iframe, full, djb2(html));
+    } else {
+        iframe.srcdoc = full;
+    }
+}
+
+function activateManagedRuntime({ source, signal }) {
+    if (!(source instanceof HTMLPreElement) || !source.isConnected || !source.parentNode) {
+        throw new Error('LittleWhiteBox managed runtime source is not a live <pre>');
+    }
+
+    const settings = getSettings();
+    const code = source.querySelector(':scope > code');
+    if (!code) throw new Error('LittleWhiteBox managed runtime source lost its <code>');
+    const html = code.textContent || '';
+    const externalUrl = extractExternalUrl(html);
+    const controller = new AbortController();
+    const timeouts = new Set();
+    const animationFrames = new Set();
+    const previousDisplay = source.style.display;
+    const wrapper = document.createElement('div');
+    const iframe = createRenderIframe();
+    let mappedWindow = null;
+    let mappedRecord = null;
+    let disposed = false;
+    let pendingManagedHeight = 0;
+    let heightFrame = null;
+    let hostAbortBound = false;
+    let messageListenerAcquired = false;
+
+    wrapper.className = 'xiaobaix-iframe-wrapper';
+    wrapper.style.margin = '0';
+
+    const scheduleTimeout = (callback, delay) => {
+        const id = setTimeout(() => {
+            timeouts.delete(id);
+            if (!controller.signal.aborted) callback();
+        }, delay);
+        timeouts.add(id);
+        return id;
+    };
+    const scheduleHeight = (height) => {
+        pendingManagedHeight = height;
+        if (heightFrame !== null) return;
+        heightFrame = requestAnimationFrame(() => {
+            animationFrames.delete(heightFrame);
+            heightFrame = null;
+            if (!controller.signal.aborted) iframe.style.height = `${pendingManagedHeight}px`;
+        });
+        animationFrames.add(heightFrame);
+    };
+    const abort = () => controller.abort(signal.reason);
+
+    const dispose = () => {
+        if (disposed) return;
+        disposed = true;
+        let firstError;
+        const run = callback => {
+            try { callback(); } catch (error) { firstError ??= error; }
+        };
+
+        run(() => controller.abort('runtime disposed'));
+        if (hostAbortBound) run(() => signal.removeEventListener('abort', abort));
+        timeouts.forEach(id => run(() => clearTimeout(id)));
+        timeouts.clear();
+        animationFrames.forEach(id => run(() => cancelAnimationFrame(id)));
+        animationFrames.clear();
+        heightFrame = null;
+        if (mappedWindow && winMap.get(mappedWindow) === mappedRecord) {
+            run(() => winMap.delete(mappedWindow));
+        }
+        run(() => { iframe.src = 'about:blank'; });
+        run(() => iframe.removeAttribute('srcdoc'));
+        // The extension-scoped 32-entry hash cache, not one runtime, owns URL revocation.
+        run(() => releaseIframeBlob(iframe));
+        run(() => iframe.remove());
+        run(() => wrapper.remove());
+        run(() => { source.style.display = previousDisplay; });
+        if (messageListenerAcquired) run(releaseManagedMessageListener);
+
+        if (firstError !== undefined) throw firstError;
+    };
+
+    try {
+        signal.addEventListener('abort', abort, { once: true });
+        hostAbortBound = true;
+        acquireManagedMessageListener();
+        messageListenerAcquired = true;
+        source.parentNode.insertBefore(wrapper, source);
+        wrapper.appendChild(iframe);
+        mappedWindow = iframe.contentWindow;
+        if (!mappedWindow) throw new Error('LittleWhiteBox managed iframe has no contentWindow');
+        mappedRecord = { iframe, wrapper, scheduleHeight };
+        winMap.set(mappedWindow, mappedRecord);
+
+        if (externalUrl) {
+            void loadExternalUrl(iframe, externalUrl, settings, {
+                signal: controller.signal,
+                scheduleTimeout,
+            });
+        } else {
+            let renderedHtml = html;
+            if (settings.variablesCore?.enabled && typeof replaceXbGetVarInString === 'function') {
+                try { renderedHtml = replaceXbGetVarInString(renderedHtml); } catch (error) {
+                    console.warn('xbgetvar 宏替换失败:', error);
+                }
+            }
+            setIframeContent(iframe, renderedHtml, settings);
+            scheduleTimeout(() => {
+                try {
+                    const targetOrigin = getIframeTargetOrigin(iframe);
+                    postToIframe(iframe, { type: 'probe' }, null, targetOrigin);
+                } catch {}
+            }, 0);
+        }
+
+        source.style.display = 'none';
+        return dispose;
+    } catch (error) {
+        try { dispose(); } catch (cleanupError) {
+            const failure = new Error('LittleWhiteBox managed runtime activation and cleanup failed');
+            failure.cause = error;
+            failure.cleanupError = cleanupError;
+            throw failure;
+        }
+        throw error;
+    }
+}
+
+export function claimManagedIframeRuntimes({ content }, claims) {
+    const settings = getSettings();
+    if (!settings.enabled || settings.renderEnabled === false) return;
+    for (const code of content.querySelectorAll('pre > code')) {
+        if (shouldRenderContentByBlock(code)) {
+            claims.claim(code.parentElement, activateManagedRuntime);
+        }
+    }
 }
 
 function getOrCreateWrapper(preEl) {
@@ -332,10 +500,15 @@ function handleIframeMessage(event) {
             }
         }
     }
+    if (!rec?.iframe) return;
     
-    if (rec && rec.iframe && typeof data.height === 'number') {
+    if (typeof data.height === 'number') {
         const next = Math.max(0, Number(data.height) || 0);
         if (next < 1) return;
+        if (rec.scheduleHeight) {
+            rec.scheduleHeight(next);
+            return;
+        }
         const prev = lastHeights.get(rec.iframe) || 0;
         if (!data.force && Math.abs(next - prev) < 1) return;
         if (data.force) {
@@ -404,13 +577,7 @@ export function renderHtmlInIframe(htmlContent, container, preElement) {
     try {
         const originalHash = djb2(htmlContent);
         const externalUrl = extractExternalUrl(htmlContent);
-        const iframe = document.createElement('iframe');
-        iframe.id = generateUniqueId();
-        iframe.className = 'xiaobaix-iframe';
-        iframe.style.cssText = 'width:100%;border:none;background:transparent;overflow:hidden;height:0;margin:0;padding:0;display:block;contain:layout paint style;will-change:height;min-height:50px';
-        iframe.setAttribute('frameborder', '0');
-        iframe.setAttribute('scrolling', 'no');
-        iframe.loading = 'eager';
+        const iframe = createRenderIframe();
         
         const wrapper = getOrCreateWrapper(preElement);
         wrapper.querySelectorAll('.xiaobaix-iframe').forEach(old => {
@@ -435,14 +602,7 @@ export function renderHtmlInIframe(htmlContent, container, preElement) {
                 }
             }
 
-            const codeHash = djb2(htmlContent);
-            const full = buildWrappedHtml(htmlContent);
-
-            if (settings.useBlob) {
-                setIframeBlobHTML(iframe, full, codeHash);
-            } else {
-                iframe.srcdoc = full;
-            }
+            setIframeContent(iframe, htmlContent, settings);
 
             try {
                 const targetOrigin = getIframeTargetOrigin(iframe);
@@ -639,8 +799,6 @@ function shrinkRenderedWindowFull() {
         });
     }
 }
-
-let messageListenerBound = false;
 
 export function initRenderer() {
     const settings = getSettings();

--- a/modules/iframe-renderer.js
+++ b/modules/iframe-renderer.js
@@ -271,6 +271,38 @@ function createRenderIframe() {
     return iframe;
 }
 
+function holdManagedRuntimePlaceholder(wrapper, iframe) {
+    const existingHeight = Number(wrapper.dataset.ttRuntimePlaceholderHeight);
+    if (existingHeight > 0) return true;
+    if (!(iframe instanceof HTMLIFrameElement)) return false;
+
+    const wrapperHeight = Math.ceil(wrapper.getBoundingClientRect().height);
+    const iframeHeight = Math.ceil(iframe.getBoundingClientRect().height);
+    if (wrapperHeight <= 0 || iframeHeight <= 0) return false;
+
+    wrapper.dataset.ttRuntimePlaceholderHeight = String(wrapperHeight);
+    wrapper.dataset.ttRuntimeIframeHeight = String(iframeHeight);
+    wrapper.style.height = `${wrapperHeight}px`;
+    wrapper.style.visibility = 'hidden';
+    wrapper.setAttribute('inert', '');
+    wrapper.setAttribute('aria-hidden', 'true');
+    return true;
+}
+
+function releaseManagedRuntimePlaceholder(wrapper, iframe) {
+    const wrapperHeight = Number(wrapper.dataset.ttRuntimePlaceholderHeight);
+    const iframeHeight = Number(wrapper.dataset.ttRuntimeIframeHeight);
+    if (!(wrapperHeight > 0) || !(iframeHeight > 0)) return;
+
+    iframe.style.height = `${iframeHeight}px`;
+    delete wrapper.dataset.ttRuntimePlaceholderHeight;
+    delete wrapper.dataset.ttRuntimeIframeHeight;
+    wrapper.style.removeProperty('height');
+    wrapper.style.removeProperty('visibility');
+    wrapper.removeAttribute('inert');
+    wrapper.removeAttribute('aria-hidden');
+}
+
 function setIframeContent(iframe, html, settings) {
     const full = buildWrappedHtml(html);
     if (settings.useBlob) {
@@ -294,7 +326,8 @@ function activateManagedRuntime({ source, signal }) {
     const timeouts = new Set();
     const animationFrames = new Set();
     const previousDisplay = source.style.display;
-    const wrapper = document.createElement('div');
+    const wrapper = getOrCreateWrapper(source);
+    const hadPlaceholder = Number(wrapper.dataset.ttRuntimePlaceholderHeight) > 0;
     const iframe = createRenderIframe();
     let mappedWindow = null;
     let mappedRecord = null;
@@ -303,9 +336,6 @@ function activateManagedRuntime({ source, signal }) {
     let heightFrame = null;
     let hostAbortBound = false;
     let messageListenerAcquired = false;
-
-    wrapper.className = 'xiaobaix-iframe-wrapper';
-    wrapper.style.margin = '0';
 
     const scheduleTimeout = (callback, delay) => {
         const id = setTimeout(() => {
@@ -327,9 +357,10 @@ function activateManagedRuntime({ source, signal }) {
     };
     const abort = () => controller.abort(signal.reason);
 
-    const dispose = () => {
+    const dispose = (preservePlaceholder) => {
         if (disposed) return;
         disposed = true;
+        const placeholderHeld = preservePlaceholder && holdManagedRuntimePlaceholder(wrapper, iframe);
         let firstError;
         const run = callback => {
             try { callback(); } catch (error) { firstError ??= error; }
@@ -350,8 +381,12 @@ function activateManagedRuntime({ source, signal }) {
         // The extension-scoped 32-entry hash cache, not one runtime, owns URL revocation.
         run(() => releaseIframeBlob(iframe));
         run(() => iframe.remove());
-        run(() => wrapper.remove());
-        run(() => { source.style.display = previousDisplay; });
+        if (placeholderHeld) {
+            run(() => { source.style.display = 'none'; });
+        } else {
+            run(() => wrapper.remove());
+            run(() => { source.style.display = previousDisplay; });
+        }
         if (messageListenerAcquired) run(releaseManagedMessageListener);
 
         if (firstError !== undefined) throw firstError;
@@ -362,8 +397,7 @@ function activateManagedRuntime({ source, signal }) {
         hostAbortBound = true;
         acquireManagedMessageListener();
         messageListenerAcquired = true;
-        source.parentNode.insertBefore(wrapper, source);
-        wrapper.appendChild(iframe);
+        wrapper.replaceChildren(iframe);
         mappedWindow = iframe.contentWindow;
         if (!mappedWindow) throw new Error('LittleWhiteBox managed iframe has no contentWindow');
         mappedRecord = { iframe, wrapper, scheduleHeight };
@@ -391,9 +425,10 @@ function activateManagedRuntime({ source, signal }) {
         }
 
         source.style.display = 'none';
-        return dispose;
+        releaseManagedRuntimePlaceholder(wrapper, iframe);
+        return () => dispose(true);
     } catch (error) {
-        try { dispose(); } catch (cleanupError) {
+        try { dispose(hadPlaceholder); } catch (cleanupError) {
             const failure = new Error('LittleWhiteBox managed runtime activation and cleanup failed');
             failure.cause = error;
             failure.cleanupError = cleanupError;

--- a/modules/message-preview.js
+++ b/modules/message-preview.js
@@ -1,6 +1,6 @@
 import { extension_settings, getContext } from "../../../../extensions.js";
 import { saveSettingsDebounced, eventSource, event_types } from "../../../../../script.js";
-import { EXT_ID } from "../core/constants.js";
+import { EXT_ID, MANAGED_CHAT_SURFACE } from "../core/constants.js";
 
 const C = { MAX_HISTORY: 10, CHECK: 200, DEBOUNCE: 300, CLEAN: 300000, TARGET: "/api/backends/chat-completions/generate", TIMEOUT: 30, ASSOC_DELAY: 1000, REQ_WINDOW: 30000 };
 const S = { active: false, isPreview: false, isLong: false, isHistoryUiBound: false, previewData: null, previewIds: new Set(), interceptedIds: [], history: [], listeners: [], resolve: null, reject: null, sendBtnWasDisabled: false, longPressTimer: null, longPressDelay: 1000, chatLenBefore: 0, restoreLong: null, cleanTimer: null, previewAbort: null, tailAPI: null, genEndedOff: null, cleanupFallback: null, pendingPurge: false };
@@ -862,6 +862,7 @@ async function interceptPreview(url, options) {
 }
 
 const addHistoryButtonsDebounced = debounce(() => {
+  if (MANAGED_CHAT_SURFACE) return;
   const set = getSettings(); if (!set.recorded.enabled || !geEnabled()) return;
   $(".mes_history_preview").remove();
   $("#chat .mes").each(function () {
@@ -872,6 +873,29 @@ const addHistoryButtonsDebounced = debounce(() => {
     $(this).find(".flex-container.flex1.alignitemscenter").append(btn);
   });
 }, C.DEBOUNCE);
+
+function mountManagedHistoryButton(message, messageId) {
+  const set = getSettings();
+  if (!set.recorded.enabled || !geEnabled() || messageId <= 0 || message.getAttribute('is_user') === 'true') return;
+  if (message.querySelector('.mes_history_preview')) return;
+
+  const button = document.createElement('div');
+  button.className = 'mes_btn mes_history_preview';
+  button.title = '查看历史API请求';
+  const icon = document.createElement('i');
+  icon.className = 'fa-regular fa-note-sticky';
+  button.appendChild(icon);
+  button.addEventListener('click', event => {
+    event.preventDefault();
+    event.stopPropagation();
+    showHistoryPreview(messageId);
+  });
+
+  if (!window.registerButtonToSubContainer?.(messageId, button)) {
+    message.querySelector('.flex-container.flex1.alignitemscenter')?.appendChild(button);
+  }
+  return () => button.remove();
+}
 
 const disableSend = (dis = true) => {
   const $b = $q("#send_but");
@@ -1014,8 +1038,10 @@ function cleanup() {
 
 function initMessagePreview() {
   try {
-    cleanup(); S.tailAPI = installEventSourceTail(eventSource);
+    cleanup();
     const set = getSettings();
+    if (MANAGED_CHAT_SURFACE && set.preview.enabled) return;
+    S.tailAPI = installEventSourceTail(eventSource);
     const btn = $(`<div id="message_preview_btn" class="fa-regular fa-note-sticky interactable" title="预览消息"></div>`);
     $("#send_but").before(btn); bindBtn();
     $("#xiaobaix_preview_enabled").prop("checked", set.preview.enabled).on("change", function () {
@@ -1043,4 +1069,4 @@ function initMessagePreview() {
 window.addEventListener("beforeunload", cleanup);
 window.messagePreviewCleanup = cleanup;
 
-export { initMessagePreview, addHistoryButtonsDebounced, cleanup };
+export { initMessagePreview, addHistoryButtonsDebounced, cleanup, mountManagedHistoryButton };

--- a/modules/story-outline/story-outline.js
+++ b/modules/story-outline/story-outline.js
@@ -26,7 +26,7 @@ import { chat_metadata, name1, processCommands, eventSource, event_types as st_e
 import { loadWorldInfo, saveWorldInfo, world_names, world_info } from "../../../../../world-info.js";
 import { getContext } from "../../../../../st-context.js";
 import { streamingGeneration } from "../streaming-generation.js";
-import { EXT_ID, extensionFolderPath } from "../../core/constants.js";
+import { EXT_ID, MANAGED_CHAT_SURFACE, extensionFolderPath } from "../../core/constants.js";
 import { createModuleEvents, event_types } from "../../core/event-manager.js";
 import { StoryOutlineStorage } from "../../core/server-storage.js";
 import { promptManager } from "../../../../../openai.js";
@@ -1500,7 +1500,7 @@ function cleanup() {
 
 // ==================== Toggle 监听（始终注册）====================
 
-$(document).on("xiaobaix:storyOutline:toggle", (_e, enabled) => {
+if (!MANAGED_CHAT_SURFACE) $(document).on("xiaobaix:storyOutline:toggle", (_e, enabled) => {
     if (enabled) {
         registerEvents();
         initBtns();
@@ -1510,7 +1510,7 @@ $(document).on("xiaobaix:storyOutline:toggle", (_e, enabled) => {
     }
 });
 
-document.addEventListener('xiaobaixEnabledChanged', e => {
+if (!MANAGED_CHAT_SURFACE) document.addEventListener('xiaobaixEnabledChanged', e => {
     if (!e?.detail?.enabled) {
         cleanup();
     } else if (getSettings().storyOutline?.enabled) {
@@ -1540,7 +1540,7 @@ async function initSettingsFromServer() {
     } catch { }
 }
 
-jQuery(() => {
+if (!MANAGED_CHAT_SURFACE) jQuery(() => {
     if (!getSettings().storyOutline?.enabled) return;
     initSettingsFromServer();
     initPromptConfigFromServer();

--- a/modules/story-summary/story-summary.js
+++ b/modules/story-summary/story-summary.js
@@ -16,7 +16,7 @@ import {
     extension_prompt_roles,
     getRequestHeaders,
 } from "../../../../../../script.js";
-import { extensionFolderPath } from "../../core/constants.js";
+import { extensionFolderPath, MANAGED_CHAT_SURFACE } from "../../core/constants.js";
 import { xbLog, CacheRegistry } from "../../core/debug-core.js";
 import { createModuleEvents } from "../../core/event-manager.js";
 import { postToIframe, isTrustedMessage } from "../../core/iframe-messaging.js";
@@ -1295,6 +1295,7 @@ function createSummaryBtn(mesId) {
 }
 
 function addSummaryBtnToMessage(mesId) {
+    if (MANAGED_CHAT_SURFACE) return;
     if (!getSettings().storySummary?.enabled) return;
     const msg = document.querySelector(`#chat .mes[mesid="${mesId}"]`);
     if (!msg || msg.querySelector(".xiaobaix-story-summary-btn")) return;
@@ -1305,7 +1306,17 @@ function addSummaryBtnToMessage(mesId) {
     msg.querySelector(".flex-container.flex1.alignitemscenter")?.appendChild(btn);
 }
 
+export function mountManagedStorySummaryButton(message, mesId) {
+    if (!getSettings().storySummary?.enabled || message.querySelector('.xiaobaix-story-summary-btn')) return;
+    const button = createSummaryBtn(mesId);
+    if (!window.registerButtonToSubContainer?.(mesId, button)) {
+        message.querySelector('.flex-container.flex1.alignitemscenter')?.appendChild(button);
+    }
+    return () => button.remove();
+}
+
 function initButtonsForAll() {
+    if (MANAGED_CHAT_SURFACE) return;
     if (!getSettings().storySummary?.enabled) return;
     $("#chat .mes").each((_, el) => {
         const mesId = el.getAttribute("mesid");
@@ -1314,6 +1325,7 @@ function initButtonsForAll() {
 }
 
 function initButtonForLatestMessage() {
+    if (MANAGED_CHAT_SURFACE) return;
     if (!getSettings().storySummary?.enabled) return;
     const { chat } = getContext();
     const mesId = Array.isArray(chat) ? chat.length - 1 : null;
@@ -2864,6 +2876,7 @@ async function handleMessageUpdated(scheduledChatId) {
 }
 
 function handleMessageRendered(data) {
+    if (MANAGED_CHAT_SURFACE) return;
     const mesId = data?.element ? $(data.element).attr("mesid") : data?.messageId;
     if (mesId != null) addSummaryBtnToMessage(mesId);
     else initButtonsForAll();

--- a/modules/template-editor/template-editor.js
+++ b/modules/template-editor/template-editor.js
@@ -1179,6 +1179,19 @@ function cleanup() {
     state.variableHistory.clear();
 }
 
+function hasActiveCustomTemplate() {
+    if (!TemplateSettings.get().enabled) return false;
+    const template = TemplateSettings.getCurrentChar();
+    return Boolean(template?.enabled && template.template);
+}
+
+function hasCustomTemplateForMessage(messageId) {
+    if (!TemplateSettings.get().enabled) return false;
+    const message = getContext()?.chat?.[messageId];
+    const template = TemplateSettings.getCharTemplate(utils.getCharAvatar(message));
+    return Boolean(template?.enabled && template.template);
+}
+
 function initTemplateEditor() {
     try { xbLog.info('templateEditor', 'initTemplateEditor'); } catch {}
     
@@ -1262,6 +1275,8 @@ export {
     openEditor,
     cleanup,
     checkEmbeddedTemplate,
+    hasActiveCustomTemplate,
+    hasCustomTemplateForMessage,
     STscript
 };
 

--- a/modules/variables/variables-panel.js
+++ b/modules/variables/variables-panel.js
@@ -1,7 +1,7 @@
 import { extension_settings, getContext, saveMetadataDebounced } from "../../../../../extensions.js";
 import { saveSettingsDebounced, chat_metadata } from "../../../../../../script.js";
 import { getLocalVariable, setLocalVariable, getGlobalVariable, setGlobalVariable } from "../../../../../variables.js";
-import { extensionFolderPath } from "../../core/constants.js";
+import { MANAGED_CHAT_SURFACE, extensionFolderPath } from "../../core/constants.js";
 import { createModuleEvents, event_types } from "../../core/event-manager.js";
 
 const CONFIG = {
@@ -639,6 +639,7 @@ class VariablesPanel {
   removeAllMessageButtons(){ $('#chat .mes .mes_btn.mes_variables_panel').remove(); }
 
   installMessageButtons(){
+    if (MANAGED_CHAT_SURFACE) return;
     const delayedAdd=(id)=> setTimeout(()=>{ if(id!=null) this.addButtonToMessage(id); },120);
     const delayedScan=()=> setTimeout(()=> this.addButtonsToAllMessages(),150);
     this.removeMessageButtonsListeners();
@@ -672,6 +673,27 @@ class VariablesPanel {
 }
 
 let variablesPanelInstance=null;
+
+export function mountManagedVariablesButton(message, messageId) {
+  if (!extension_settings[EXT_ID]?.variablesPanel?.enabled || message.querySelector('.mes_variables_panel')) return;
+  const button=document.createElement('div');
+  button.className='mes_btn mes_variables_panel';
+  button.title='变量面板';
+  button.dataset.mid=messageId;
+  const icon=document.createElement('i');
+  icon.className='fa-solid fa-database';
+  button.appendChild(icon);
+  button.addEventListener('click',(event)=>{
+    event.preventDefault(); event.stopPropagation();
+    void Promise.resolve(variablesPanelInstance || initVariablesPanel())
+      .then(instance=>instance.open())
+      .catch(error=>console.error(`[${CONFIG.extensionName}] 打开失败:`,error));
+  });
+  if (!window.registerButtonToSubContainer?.(messageId,button)) {
+    message.querySelector('.flex-container.flex1.alignitemscenter')?.appendChild(button);
+  }
+  return ()=>button.remove();
+}
 
 export async function initVariablesPanel(){
   try{

--- a/widgets/button-collapse.js
+++ b/widgets/button-collapse.js
@@ -220,6 +220,21 @@ const registerButtonToSubContainer = (messageId, buttonEl) => {
   return true;
 };
 
+const mountManagedButtonCollapse = (message) => {
+  const collapseBtn = message?.querySelector(SELECTORS.collapse);
+  if (!collapseBtn) return;
+  return () => {
+    const sub = collapseBtn.querySelector('.xiaobaix-sub-container');
+    const mesButtons = message.querySelector(SELECTORS.mesButtons);
+    if (sub && mesButtons) {
+      mesButtons.classList.remove('xiaobaix-expanded');
+      while (sub.firstChild) mesButtons.appendChild(sub.firstChild);
+    }
+    collapseBtn.remove();
+    processed.delete(message);
+  };
+};
+
 const cleanup = () => {
   io?.disconnect(); io = null;
   mo?.disconnect(); mo = null;
@@ -256,4 +271,4 @@ if (typeof window !== 'undefined') {
   });
 }
 
-export { initButtonCollapse, cleanup, registerButtonToSubContainer, processButtonCollapse };
+export { initButtonCollapse, cleanup, registerButtonToSubContainer, processButtonCollapse, mountManagedButtonCollapse };


### PR DESCRIPTION
~~实在是对酒馆的卡顿深恶痛绝于是~~ TauriTavern 在 [2.2.0 版本](https://github.com/Darkatse/TauriTavern/releases/tag/v2.2.0) 引入了聊天 DOM 虚拟化，试图解决长聊天的性能问题。

在开启聊天 DOM 虚拟化后，消息节点会随可视窗口挂载和卸载。那么小白X 需要通过新加入 ChatSurface API 管理消息内容及 iframe runtime 的生命周期，避免重复渲染、资源残留和滚动高度塌缩。也就是让宿主统一管理iframe。

对此的改动为：
- 接入 ChatSurface v1 participant。
- managed 模式下按需创建和回收 iframe runtime。
- 通过 `didMount` 管理历史、变量、剧情总结及折叠按钮。
- runtime 回收时保留等高 inert placeholder，避免滚动跳动。
- managed 模式不再启动原有 DOM observer 和 renderer。
- 保留原有 static renderer；在 SillyTavern 或未开启虚拟化时，行为不变。

尚未适配的沉浸模式、消息预览、TTS、绘图、自定义模板等功能会明确拒绝启动，不会静默使用。

如果需要的话，具体的ChatSurface API文档为：https://tauritavern.github.io/api/chat-surface