### PR TITLE
Feat/story summary delay floors

### DIFF
--- a/modules/story-summary/data/config.js
+++ b/modules/story-summary/data/config.js
@@ -425,6 +425,7 @@ function createDefaultSummaryPanelConfig() {
         trigger: {
             enabled: false,
             interval: 20,
+            delayFloors: 0,
             timing: "before_user",
             role: "system",
             useStream: true,
@@ -515,6 +516,8 @@ function normalizeSummaryPanelConfig(rawConfig = null) {
         result.trigger.timing = defaults.trigger.timing;
     }
     if (result.trigger.useStream === undefined) result.trigger.useStream = true;
+    const delayFloors = Number.parseInt(result.trigger.delayFloors, 10);
+    result.trigger.delayFloors = Number.isFinite(delayFloors) ? Math.max(0, Math.min(30, delayFloors)) : 0;
     result.ui.hideSummarized = !!result.ui.hideSummarized;
     result.ui.keepVisibleCount = clampKeepVisibleCount(result.ui.keepVisibleCount);
     result.ui.useVectorBoundary = result.ui.useVectorBoundary !== false;

--- a/modules/story-summary/data/store.js
+++ b/modules/story-summary/data/store.js
@@ -432,7 +432,7 @@ export function isSummaryRollbackRequired(store, currentLength) {
     const lastSummarized = Number(store?.lastSummarizedMesId);
     if (!Number.isInteger(lastSummarized) || lastSummarized < 0) return false;
     const length = Math.max(0, Math.trunc(Number(currentLength) || 0));
-    return length <= lastSummarized && lastSummarized + 1 - length >= 2;
+    return length <= lastSummarized && lastSummarized + 1 - length >= 1;
 }
 
 export function isSummaryConsumable(store, currentLength) {

--- a/modules/story-summary/story-summary-ui.js
+++ b/modules/story-summary/story-summary-ui.js
@@ -1160,6 +1160,7 @@ import { EVENT_MEMORY_ROLES, projectEditedSummaryEvents } from './data/events.js
         $('gen-frequency').value = config.gen.frequency_penalty ?? '';
         $('trigger-enabled').checked = config.trigger.enabled;
         $('trigger-interval').value = config.trigger.interval;
+        $('trigger-delay-floors').value = config.trigger.delayFloors ?? 0;
         $('trigger-timing').value = config.trigger.timing;
         $('trigger-role').value = config.trigger.role || 'system';
         $('trigger-stream').checked = config.trigger.useStream !== false;
@@ -1236,6 +1237,7 @@ import { EVENT_MEMORY_ROLES, projectEditedSummaryEvents } from './data/events.js
         config.trigger.role = $('trigger-role').value || 'system';
         config.trigger.enabled = $('trigger-enabled').checked;
         config.trigger.interval = Math.max(1, Math.min(30, parseInt($('trigger-interval').value) || 20));
+        config.trigger.delayFloors = Math.max(0, Math.min(30, parseInt($('trigger-delay-floors').value) || 0));
         config.trigger.useStream = $('trigger-stream').checked;
         config.trigger.maxPerRun = parseInt($('trigger-max-per-run').value) || 100;
         config.trigger.wrapperHead = $('trigger-wrapper-head').value;
@@ -2622,6 +2624,13 @@ import { EVENT_MEMORY_ROLES, projectEditedSummaryEvents } from './data/events.js
         $('trigger-interval').onchange = e => {
             let val = parseInt(e.target.value) || 20;
             val = Math.max(1, Math.min(30, val));
+            e.target.value = val;
+        };
+
+        // 延迟总结楼层范围校验
+        $('trigger-delay-floors').onchange = e => {
+            let val = parseInt(e.target.value) || 0;
+            val = Math.max(0, Math.min(30, val));
             e.target.value = val;
         };
 

--- a/modules/story-summary/story-summary.html
+++ b/modules/story-summary/story-summary.html
@@ -423,6 +423,10 @@
                                             <option value="before_user" selected>用户发送前</option>
                                         </select>
                                     </div>
+                                    <div class="settings-field">
+                                        <label title="保留最近 N 层不纳入总结，手动与自动一致；0 = 总结到最新">延迟总结楼层</label>
+                                        <input type="number" id="trigger-delay-floors" min="0" max="30" step="1" value="0">
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/modules/story-summary/story-summary.js
+++ b/modules/story-summary/story-summary.js
@@ -3056,7 +3056,8 @@ async function maybeAutoRunSummary(reason) {
 
     const store = getSummaryStore();
     const lastSummarized = store?.lastSummarizedMesId ?? -1;
-    const target = getSummarySourceEnd(chat, chat.length - 1);
+    const sourceEnd = getSummarySourceEnd(chat, chat.length - 1);
+    const target = Math.min(sourceEnd, chat.length - 1 - (Number(trig?.delayFloors) || 0));
     const pending = target - lastSummarized;
     if (pending < (trig.interval || 1)) return;
 
@@ -3206,7 +3207,7 @@ async function handleFrameMessage(event) {
                 break;
             }
             const ctx = getContext();
-            currentMesId = (ctx.chat?.length ?? 1) - 1;
+            currentMesId = (ctx.chat?.length ?? 1) - 1 - (Number(getSummaryPanelConfig()?.trigger?.delayFloors) || 0);
             handleManualGenerate(currentMesId, data.config || {});
             break;
         }


### PR DESCRIPTION
- 增加一个延迟总结的功能，解决的痛点是，最后一层刚好是被总结的状态，然后又要roll的时候l2会不准确
- 由于有延迟总结的功能，可以让l2严格回滚，不用留宽容度